### PR TITLE
Harden unauthenticated paths: rate limits, fail-closed auth secret, frame headers

### DIFF
--- a/apps/api/src/app.tsx
+++ b/apps/api/src/app.tsx
@@ -24,7 +24,7 @@ import { groupRoutes } from "./routes/groups";
 import { ogRoutes, warmOgCard } from "./routes/og";
 import { recoveryRoutes } from "./routes/recovery";
 import { groupLinkFromQuery, inviteFromQuery, ownerRoutes, viewerHandles } from "./routes/owner";
-import { createOwnerAuth, OWNER_SESSION_COOKIES } from "./lib/owner-auth";
+import { createOwnerAuth, OWNER_SESSION_COOKIES, type OwnerAuth } from "./lib/owner-auth";
 import { stripeRoutes } from "./routes/stripe";
 import { apiMd, cliPrefix, skillMd } from "./skill";
 import { createMcpRoutes } from "./mcp";
@@ -75,6 +75,22 @@ Then read ${origin}/skill.md for what to tell your human. Without node, redeem b
 with your token (POST ${origin}/api/invites/${token}/redeem, \`Authorization: Bearer hn_...\`);
 ${origin}/api.md has the rest.
 `;
+}
+
+// Better Auth builds its plugin graph on construction, and most requests
+// (bot API calls) never touch owner auth, so it is built on first use. Only
+// `api` and `handler` are consumed.
+function lazyOwnerAuth(make: () => OwnerAuth): OwnerAuth {
+  let auth: OwnerAuth | undefined;
+  const get = () => (auth ??= make());
+  return {
+    get api() {
+      return get().api;
+    },
+    get handler() {
+      return get().handler;
+    },
+  } as OwnerAuth;
 }
 
 // The profile shell is a static page; the share metadata (title, card image)
@@ -136,7 +152,9 @@ export function createApp(overrides?: {
     c.set("ownerSignedIn", OWNER_SESSION_COOKIES.some((name) => Boolean(getCookie(c, name))));
     c.set(
       "ownerAuth",
-      createOwnerAuth({ db: c.get("db"), origin: c.get("origin"), env: c.env ?? {}, sendEmail: c.get("sendEmail") }),
+      lazyOwnerAuth(() =>
+        createOwnerAuth({ db: c.get("db"), origin: c.get("origin"), env: c.env ?? {}, sendEmail: c.get("sendEmail") }),
+      ),
     );
     c.set("waitUntil", overrides?.waitUntil ?? ((p) => {
       try {
@@ -146,6 +164,12 @@ export function createApp(overrides?: {
       }
     }));
     await next();
+    // No page here is meant to be framed. Keeps the dashboard's one-click
+    // forms (ack, toggles) out of reach of clickjacking.
+    if (c.res.headers.get("content-type")?.includes("text/html")) {
+      c.res.headers.set("content-security-policy", "frame-ancestors 'none'");
+      c.res.headers.set("x-frame-options", "DENY");
+    }
   });
 
   app.get("/skill.md", (c) =>

--- a/apps/api/src/app.tsx
+++ b/apps/api/src/app.tsx
@@ -77,9 +77,6 @@ ${origin}/api.md has the rest.
 `;
 }
 
-// Better Auth builds its plugin graph on construction, and most requests
-// (bot API calls) never touch owner auth, so it is built on first use. Only
-// `api` and `handler` are consumed.
 function lazyOwnerAuth(make: () => OwnerAuth): OwnerAuth {
   let auth: OwnerAuth | undefined;
   const get = () => (auth ??= make());
@@ -164,8 +161,6 @@ export function createApp(overrides?: {
       }
     }));
     await next();
-    // No page here is meant to be framed. Keeps the dashboard's one-click
-    // forms (ack, toggles) out of reach of clickjacking.
     if (c.res.headers.get("content-type")?.includes("text/html")) {
       c.res.headers.set("content-security-policy", "frame-ancestors 'none'");
       c.res.headers.set("x-frame-options", "DENY");

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -24,6 +24,11 @@ export type Bindings = {
   // Encrypts notification endpoints at rest.
   NOTIFICATION_ENCRYPTION_KEY?: string;
   ASSETS?: Fetcher;
+  // Workers rate-limit bindings (wrangler.jsonc "ratelimits"): in-memory
+  // per-colo counters for unauthenticated paths. Absent outside Workers.
+  SIGNUP_LIMIT?: RateLimit;
+  EMAIL_LIMIT?: RateLimit;
+  LOOKUP_LIMIT?: RateLimit;
 };
 
 export type Variables = {

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -24,8 +24,6 @@ export type Bindings = {
   // Encrypts notification endpoints at rest.
   NOTIFICATION_ENCRYPTION_KEY?: string;
   ASSETS?: Fetcher;
-  // Workers rate-limit bindings (wrangler.jsonc "ratelimits"): in-memory
-  // per-colo counters for unauthenticated paths. Absent outside Workers.
   SIGNUP_LIMIT?: RateLimit;
   EMAIL_LIMIT?: RateLimit;
   LOOKUP_LIMIT?: RateLimit;

--- a/apps/api/src/lib/owner-auth.ts
+++ b/apps/api/src/lib/owner-auth.ts
@@ -32,15 +32,14 @@ export function ownerProviders(env: OwnerAuthEnv): OwnerProviders {
   };
 }
 
-let warnedSecret = false;
-
 export function createOwnerAuth(opts: { db: Db; origin: string; env: OwnerAuthEnv; sendEmail: SendEmail }) {
   const { db, origin, env, sendEmail } = opts;
   const providers = ownerProviders(env);
   const production = origin.startsWith("https://");
-  if (!env.BETTER_AUTH_SECRET && production && !warnedSecret) {
-    warnedSecret = true;
-    console.error("BETTER_AUTH_SECRET is unset in production; owner sessions use a placeholder secret");
+  // A known placeholder secret would let anyone forge owner sessions, so a
+  // deployment without the real one refuses owner sign-in instead.
+  if (!env.BETTER_AUTH_SECRET && production) {
+    throw new Error("BETTER_AUTH_SECRET is unset; owner sign-in is disabled until it is configured");
   }
   return betterAuth({
     appName: "hi.new",

--- a/apps/api/src/lib/owner-auth.ts
+++ b/apps/api/src/lib/owner-auth.ts
@@ -36,8 +36,6 @@ export function createOwnerAuth(opts: { db: Db; origin: string; env: OwnerAuthEn
   const { db, origin, env, sendEmail } = opts;
   const providers = ownerProviders(env);
   const production = origin.startsWith("https://");
-  // A known placeholder secret would let anyone forge owner sessions, so a
-  // deployment without the real one refuses owner sign-in instead.
   if (!env.BETTER_AUTH_SECRET && production) {
     throw new Error("BETTER_AUTH_SECRET is unset; owner sign-in is disabled until it is configured");
   }

--- a/apps/api/src/lib/ratelimit.ts
+++ b/apps/api/src/lib/ratelimit.ts
@@ -1,4 +1,6 @@
 import { sql } from "drizzle-orm";
+import type { Context } from "hono";
+import type { AppEnv } from "../context";
 import type { Db } from "../db/client";
 import { rateCounters } from "../db/schema";
 
@@ -28,5 +30,42 @@ export async function takeRate(
 export const RATE = {
   dmPerHour: { kind: "dm", limit: 100, windowSeconds: 3600 },
   invitesPerDay: { kind: "invite", limit: 20, windowSeconds: 86400 },
-  signupPerHourPerIp: { kind: "signup", limit: 20, windowSeconds: 3600 },
 } as const;
+
+// Unauthenticated paths have no handle to count against, so they use the
+// Workers rate-limit binding: an in-memory counter in the colo, no network
+// hop. The limits themselves live in wrangler.jsonc. Without the binding
+// (tests, bun, local node) everything is allowed.
+export async function takeEdgeRate(limiter: RateLimit | undefined, key: string): Promise<boolean> {
+  if (!limiter) return true;
+  try {
+    return (await limiter.limit({ key })).success;
+  } catch (err) {
+    console.error("rate limit binding failed", err);
+    return true;
+  }
+}
+
+// One verification or recovery mail per call, counted against both the
+// caller's address and the mailbox it targets.
+export async function takeEmailRate(c: Context<AppEnv>, to: string): Promise<boolean> {
+  const limiter = c.env?.EMAIL_LIMIT;
+  const [byIp, byTo] = await Promise.all([
+    takeEdgeRate(limiter, `ip:${clientIp(c)}`),
+    takeEdgeRate(limiter, `to:${to.toLowerCase()}`),
+  ]);
+  return byIp && byTo;
+}
+
+export function clientIp(c: Context<AppEnv>): string {
+  return (
+    c.req.header("cf-connecting-ip") ||
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown"
+  );
+}
+
+export function rateLimited(c: Context<AppEnv>, hint: string) {
+  c.header("Retry-After", "60");
+  return c.json({ error: "rate_limited", hint }, 429);
+}

--- a/apps/api/src/lib/ratelimit.ts
+++ b/apps/api/src/lib/ratelimit.ts
@@ -32,10 +32,6 @@ export const RATE = {
   invitesPerDay: { kind: "invite", limit: 20, windowSeconds: 86400 },
 } as const;
 
-// Unauthenticated paths have no handle to count against, so they use the
-// Workers rate-limit binding: an in-memory counter in the colo, no network
-// hop. The limits themselves live in wrangler.jsonc. Without the binding
-// (tests, bun, local node) everything is allowed.
 export async function takeEdgeRate(limiter: RateLimit | undefined, key: string): Promise<boolean> {
   if (!limiter) return true;
   try {
@@ -46,8 +42,6 @@ export async function takeEdgeRate(limiter: RateLimit | undefined, key: string):
   }
 }
 
-// One verification or recovery mail per call, counted against both the
-// caller's address and the mailbox it targets.
 export async function takeEmailRate(c: Context<AppEnv>, to: string): Promise<boolean> {
   const limiter = c.env?.EMAIL_LIMIT;
   const [byIp, byTo] = await Promise.all([

--- a/apps/api/src/routes/handles.ts
+++ b/apps/api/src/routes/handles.ts
@@ -14,6 +14,7 @@ import { checkName, priceCentsFor } from "@hi-new/domain";
 import { isAgePublicKey } from "../lib/keys";
 import { newSetupCode, openToken, sealToken, setupCodeHash } from "../lib/setup-code";
 import { recordPayment } from "../lib/payments";
+import { clientIp, rateLimited, takeEdgeRate, takeEmailRate } from "../lib/ratelimit";
 import { renewalView } from "../lib/renewal";
 import { fingerprint, randomToken, sha256Hex } from "../lib/tokens";
 import { isSafeWebhookUrl } from "../lib/webhook";
@@ -142,6 +143,15 @@ handleRoutes.post("/api/handles", async (c) => {
   if ("error" in webhookCheck) return c.json({ error: webhookCheck.error }, 400);
   const colorCheck = validateOptionalColor(body.color);
   if ("error" in colorCheck) return c.json({ error: colorCheck.error }, 400);
+
+  // Claims need no credential, so the brake is per caller address; the
+  // verification mail is also counted against the mailbox it targets.
+  if (!(await takeEdgeRate(c.env?.SIGNUP_LIMIT, clientIp(c)))) {
+    return rateLimited(c, "Too many claims from this address. Try again in a minute.");
+  }
+  if (email && !emailVerifiedAt && !(await takeEmailRate(c, email))) {
+    return rateLimited(c, "Too many verification emails. Try again in a minute.");
+  }
 
   const { name, priceCents } = nameCheck;
   const db = c.get("db");
@@ -508,6 +518,9 @@ handleRoutes.patch("/api/handles/me", requireAuth, requireScope("profile:write")
           409,
         );
       }
+      if (!(await takeEmailRate(c, newEmail))) {
+        return rateLimited(c, "Too many verification emails. Try again in a minute.");
+      }
       updates.email = newEmail;
       updates.emailVerifiedAt = null;
     } else {
@@ -636,6 +649,10 @@ handleRoutes.get("/api/stats/claims", async (c) => {
 handleRoutes.get("/api/handles/:name", async (c) => {
   const nameCheck = checkName(c.req.param("name"), { allowHouse: true });
   if (!nameCheck.ok) return c.json({ error: nameCheck.error }, 400);
+  // Public by design, but not a directory: a dictionary sweep gets throttled.
+  if (!(await takeEdgeRate(c.env?.LOOKUP_LIMIT, clientIp(c)))) {
+    return rateLimited(c, "Too many lookups from this address. Try again in a minute.");
+  }
   const db = c.get("db");
   // The house bot exists from the first time anyone asks about it.
   if (nameCheck.name === HOUSE_BOT_NAME) await ensureHouseBot(db);

--- a/apps/api/src/routes/handles.ts
+++ b/apps/api/src/routes/handles.ts
@@ -144,8 +144,6 @@ handleRoutes.post("/api/handles", async (c) => {
   const colorCheck = validateOptionalColor(body.color);
   if ("error" in colorCheck) return c.json({ error: colorCheck.error }, 400);
 
-  // Claims need no credential, so the brake is per caller address; the
-  // verification mail is also counted against the mailbox it targets.
   if (!(await takeEdgeRate(c.env?.SIGNUP_LIMIT, clientIp(c)))) {
     return rateLimited(c, "Too many claims from this address. Try again in a minute.");
   }
@@ -649,7 +647,6 @@ handleRoutes.get("/api/stats/claims", async (c) => {
 handleRoutes.get("/api/handles/:name", async (c) => {
   const nameCheck = checkName(c.req.param("name"), { allowHouse: true });
   if (!nameCheck.ok) return c.json({ error: nameCheck.error }, 400);
-  // Public by design, but not a directory: a dictionary sweep gets throttled.
   if (!(await takeEdgeRate(c.env?.LOOKUP_LIMIT, clientIp(c)))) {
     return rateLimited(c, "Too many lookups from this address. Try again in a minute.");
   }

--- a/apps/api/src/routes/owner.tsx
+++ b/apps/api/src/routes/owner.tsx
@@ -526,8 +526,6 @@ ownerRoutes.post("/owner/handles/:id/email", async (c) => {
     : [];
   if (!handle) return c.redirect("/owner", 303);
   const db = c.get("db");
-  // Earlier move links die with the request they belonged to, so a stale
-  // link in one mailbox can never confirm a move to a different address.
   const retirePriorMoves = () =>
     db
       .update(emailTokens)

--- a/apps/api/src/routes/owner.tsx
+++ b/apps/api/src/routes/owner.tsx
@@ -526,8 +526,16 @@ ownerRoutes.post("/owner/handles/:id/email", async (c) => {
     : [];
   if (!handle) return c.redirect("/owner", 303);
   const db = c.get("db");
+  // Earlier move links die with the request they belonged to, so a stale
+  // link in one mailbox can never confirm a move to a different address.
+  const retirePriorMoves = () =>
+    db
+      .update(emailTokens)
+      .set({ usedAt: new Date() })
+      .where(and(eq(emailTokens.handleId, handle.id), eq(emailTokens.kind, "move"), isNull(emailTokens.usedAt)));
   if (form.cancel === "true") {
     await db.update(handles).set({ pendingEmail: null }).where(eq(handles.id, handle.id));
+    await retirePriorMoves();
     return c.redirect("/owner", 303);
   }
   const target = typeof form.email === "string" ? form.email.trim().toLowerCase() : "";
@@ -535,6 +543,7 @@ ownerRoutes.post("/owner/handles/:id/email", async (c) => {
   if (target === email) return c.redirect("/owner", 303);
   if (handle.tier === "free" && !(await emailHasRoom(db, target))) return c.redirect("/owner?error=move_limit", 303);
   await db.update(handles).set({ pendingEmail: target }).where(eq(handles.id, handle.id));
+  await retirePriorMoves();
   const token = randomToken("hnm");
   await db.insert(emailTokens).values({
     handleId: handle.id,

--- a/apps/api/src/routes/recovery.tsx
+++ b/apps/api/src/routes/recovery.tsx
@@ -3,6 +3,7 @@ import { Hono, type Context } from "hono";
 import { RECOVER_TTL_MS, type AppEnv } from "../context";
 import { emailTokens, handles } from "../db/schema";
 import { recoverEmailText } from "../lib/email";
+import { takeEmailRate } from "../lib/ratelimit";
 import { randomToken, sha256Hex } from "../lib/tokens";
 import { Page } from "../pages/layout";
 import { renderPage } from "../pages/render";
@@ -105,6 +106,8 @@ recoveryRoutes.get("/recover", (c) =>
 );
 
 async function requestRecovery(c: Context<AppEnv>, name: string, email: string): Promise<void> {
+  // Same response either way: a throttled request just sends nothing.
+  if (!(await takeEmailRate(c, email))) return;
   const db = c.get("db");
   const [handle] = await db
     .select()

--- a/apps/api/src/routes/recovery.tsx
+++ b/apps/api/src/routes/recovery.tsx
@@ -106,7 +106,6 @@ recoveryRoutes.get("/recover", (c) =>
 );
 
 async function requestRecovery(c: Context<AppEnv>, name: string, email: string): Promise<void> {
-  // Same response either way: a throttled request just sends nothing.
   if (!(await takeEmailRate(c, email))) return;
   const db = c.get("db");
   const [handle] = await db

--- a/apps/api/src/skill.ts
+++ b/apps/api/src/skill.ts
@@ -701,6 +701,7 @@ asserted by our auth, not cryptographically signed (yet).
 Errors are JSON: \`{"error": "...", "hint": "..."}\`. \`401\` bad token, \`402\` unpaid
 name, \`403\` no grant, \`404\` unknown or available profile, \`409\` conflict such as a
 taken name, email policy cap, or reused idempotency key, \`410\` acknowledged or expired
-content, \`413\` too big, and \`429\` rate limited.
+content, \`413\` too big, and \`429\` rate limited (claims, lookups, and verification mail are
+throttled per address; wait for \`Retry-After\` seconds).
 `;
 }

--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -587,7 +587,6 @@ describe("owner email moves", () => {
     expect((await move("dave@owners.example")).status).toBe(303);
     const daveLink = linkFrom(sent[0]!.text, "/v/");
 
-    // Carol's link belonged to a request that no longer exists.
     expect((await app.request(`http://hi.test${carolLink}`)).status).toBe(410);
     let [handle] = await db.select().from(handles).where(eq(handles.id, row!.id));
     expect(handle!.email).toBe("alice-bot@owners.example");

--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -565,3 +565,37 @@ describe("sign-in destinations", () => {
     expect(confirm).toContain("callbackURL=%2Falice-bot");
   });
 });
+
+describe("owner email moves", () => {
+  test("a superseded move link cannot confirm the newer target", async () => {
+    const { app, db, sent } = await makeTestApp();
+    await signup(app, "alice-bot");
+    await verifyLatest(app, sent.at(-1)!.text);
+    const cookie = await signIn(app, sent, "alice-bot@owners.example");
+    const [row] = await db.select({ id: handles.id }).from(handles).where(eq(handles.name, "alice-bot"));
+    const move = (email: string) =>
+      app.request(`http://hi.test/owner/handles/${row!.id}/email`, {
+        ...form("email=" + encodeURIComponent(email)),
+        headers: { "content-type": "application/x-www-form-urlencoded", cookie },
+        redirect: "manual",
+      });
+
+    sent.length = 0;
+    expect((await move("carol@owners.example")).status).toBe(303);
+    const carolLink = linkFrom(sent[0]!.text, "/v/");
+    sent.length = 0;
+    expect((await move("dave@owners.example")).status).toBe(303);
+    const daveLink = linkFrom(sent[0]!.text, "/v/");
+
+    // Carol's link belonged to a request that no longer exists.
+    expect((await app.request(`http://hi.test${carolLink}`)).status).toBe(410);
+    let [handle] = await db.select().from(handles).where(eq(handles.id, row!.id));
+    expect(handle!.email).toBe("alice-bot@owners.example");
+    expect(handle!.pendingEmail).toBe("dave@owners.example");
+
+    expect((await app.request(`http://hi.test${daveLink}`)).status).toBe(200);
+    [handle] = await db.select().from(handles).where(eq(handles.id, row!.id));
+    expect(handle!.email).toBe("dave@owners.example");
+    expect(handle!.pendingEmail).toBeNull();
+  });
+});

--- a/apps/api/test/security.test.ts
+++ b/apps/api/test/security.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { handles } from "../src/db/schema";
+import { createOwnerAuth } from "../src/lib/owner-auth";
+import { call, makeTestApp, makeTestDb, signup, type TestApp } from "./helpers";
+
+// Stand-in for the Workers rate-limit binding: `limit` hits per key.
+function limiter(limit: number) {
+  const hits = new Map<string, number>();
+  return {
+    async limit({ key }: { key: string }) {
+      const n = (hits.get(key) ?? 0) + 1;
+      hits.set(key, n);
+      return { success: n <= limit };
+    },
+  };
+}
+
+type Env = Record<string, unknown>;
+
+async function request(
+  app: TestApp,
+  method: string,
+  path: string,
+  env: Env,
+  opts: { body?: unknown; token?: string; ip?: string } = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "cf-connecting-ip": opts.ip ?? "203.0.113.7",
+  };
+  if (opts.token) headers.authorization = `Bearer ${opts.token}`;
+  const res = await app.request(
+    `http://hi.test${path}`,
+    { method, headers, body: opts.body === undefined ? undefined : JSON.stringify(opts.body) },
+    env,
+  );
+  const json: any = await res.json().catch(() => null);
+  return { status: res.status, headers: res.headers, json };
+}
+
+describe("unauthenticated rate limits", () => {
+  test("claims are throttled per caller address", async () => {
+    const { app, db } = await makeTestApp();
+    const env = { SIGNUP_LIMIT: limiter(2) };
+    expect((await request(app, "POST", "/api/handles", env, { body: { name: "first-bot" } })).status).toBe(201);
+    expect((await request(app, "POST", "/api/handles", env, { body: { name: "second-bot" } })).status).toBe(201);
+    const third = await request(app, "POST", "/api/handles", env, { body: { name: "third-bot" } });
+    expect(third.status).toBe(429);
+    expect(third.json.error).toBe("rate_limited");
+    expect(third.headers.get("retry-after")).toBe("60");
+    expect(await db.select().from(handles).where(eq(handles.name, "third-bot"))).toHaveLength(0);
+    // Another address is unaffected.
+    expect((await request(app, "POST", "/api/handles", env, { body: { name: "third-bot" }, ip: "198.51.100.9" })).status).toBe(201);
+  });
+
+  test("verification and recovery mail is capped per address and per mailbox", async () => {
+    const { app, db, sent } = await makeTestApp();
+    const env = { EMAIL_LIMIT: limiter(2) };
+    const shared = "shared@owners.example";
+    expect((await request(app, "POST", "/api/handles", env, { body: { name: "alpha-bot", email: shared } })).status).toBe(201);
+    expect((await request(app, "POST", "/api/handles", env, { body: { name: "bravo-bot", email: shared } })).status).toBe(201);
+    expect(sent).toHaveLength(2);
+    // Third mail to the same mailbox in the window is refused before anything is created.
+    const capped = await request(app, "POST", "/api/handles", env, { body: { name: "charlie-bot", email: shared } });
+    expect(capped.status).toBe(429);
+    expect(sent).toHaveLength(2);
+    expect(await db.select().from(handles).where(eq(handles.name, "charlie-bot"))).toHaveLength(0);
+    // Claiming without an email sends nothing and is not counted here.
+    const c = await request(app, "POST", "/api/handles", env, { body: { name: "charlie-bot" } });
+    expect(c.status).toBe(201);
+
+    // Re-pointing an unverified email sends a mail each time; the caller's address caps it.
+    const patch = (email: string) =>
+      request(app, "PATCH", "/api/handles/me", env, { token: c.json.token, body: { email }, ip: "198.51.100.9" });
+    expect((await patch("one@owners.example")).status).toBe(200);
+    expect((await patch("two@owners.example")).status).toBe(200);
+    expect((await patch("three@owners.example")).status).toBe(429);
+    expect(sent).toHaveLength(4);
+    const [me] = await db.select().from(handles).where(eq(handles.name, "charlie-bot"));
+    expect(me!.email).toBe("two@owners.example");
+
+    // Recovery keeps its uniform response; a throttled request just sends nothing.
+    const d = await request(app, "POST", "/api/handles", env, { body: { name: "delta-bot", email: "d@owners.example" }, ip: "192.0.2.1" });
+    expect(d.status).toBe(201);
+    const recover = (ip: string) =>
+      request(app, "POST", "/api/recover", env, { body: { name: "delta-bot", email: "d@owners.example" }, ip });
+    expect((await recover("192.0.2.2")).status).toBe(200);
+    expect(sent.at(-1)!.subject).toBe("Recover hi.new/delta-bot");
+    const before = sent.length;
+    expect((await recover("192.0.2.3")).status).toBe(200);
+    expect(sent).toHaveLength(before);
+  });
+
+  test("profile lookups are throttled per caller address", async () => {
+    const { app } = await makeTestApp();
+    await signup(app, "alice-bot");
+    const env = { LOOKUP_LIMIT: limiter(1) };
+    expect((await request(app, "GET", "/api/handles/alice-bot", env)).status).toBe(200);
+    expect((await request(app, "GET", "/api/handles/alice-bot", env)).status).toBe(429);
+    expect((await request(app, "GET", "/api/handles/alice-bot", env, { ip: "198.51.100.9" })).status).toBe(200);
+  });
+
+  test("without the binding nothing is throttled", async () => {
+    const { app } = await makeTestApp();
+    for (let i = 0; i < 12; i++) {
+      expect((await request(app, "POST", "/api/handles", {}, { body: { name: `bot-${i}-many` } })).status).toBe(201);
+    }
+  });
+});
+
+describe("owner sign-in secret", () => {
+  test("production refuses to run on the placeholder secret", async () => {
+    const db = await makeTestDb();
+    const sendEmail = async () => {};
+    expect(() => createOwnerAuth({ db, origin: "https://hi.new", env: {}, sendEmail })).toThrow(/BETTER_AUTH_SECRET/);
+    expect(() => createOwnerAuth({ db, origin: "https://hi.new", env: { BETTER_AUTH_SECRET: "x".repeat(32) }, sendEmail })).not.toThrow();
+    expect(() => createOwnerAuth({ db, origin: "http://localhost:8787", env: {}, sendEmail })).not.toThrow();
+  });
+
+  test("a missing secret only affects owner sign-in, not the bot API", async () => {
+    const { app } = await makeTestApp();
+    const env = { APP_ORIGIN: "https://hi.test" };
+    const alice = await signup(app, "alice-bot");
+    expect((await request(app, "GET", "/api/handles/me", env, { token: alice.token })).status).toBe(200);
+    expect((await request(app, "GET", "/owner", env)).status).toBe(500);
+  });
+});
+
+describe("framing", () => {
+  test("html pages refuse to be framed; json does not carry the headers", async () => {
+    const { app } = await makeTestApp();
+    const alice = await signup(app, "alice-bot");
+    for (const path of ["/alice-bot", "/owner", "/recover"]) {
+      const res = await app.request(`http://hi.test${path}`);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("x-frame-options")).toBe("DENY");
+      expect(res.headers.get("content-security-policy")).toBe("frame-ancestors 'none'");
+    }
+    const res = await app.request("http://hi.test/api/handles/me", { headers: { authorization: `Bearer ${alice.token}` } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-frame-options")).toBeNull();
+    expect((await call(app, "GET", "/api/handles/alice-bot")).status).toBe(200);
+  });
+});

--- a/apps/api/test/security.test.ts
+++ b/apps/api/test/security.test.ts
@@ -4,7 +4,6 @@ import { handles } from "../src/db/schema";
 import { createOwnerAuth } from "../src/lib/owner-auth";
 import { call, makeTestApp, makeTestDb, signup, type TestApp } from "./helpers";
 
-// Stand-in for the Workers rate-limit binding: `limit` hits per key.
 function limiter(limit: number) {
   const hits = new Map<string, number>();
   return {
@@ -50,7 +49,6 @@ describe("unauthenticated rate limits", () => {
     expect(third.json.error).toBe("rate_limited");
     expect(third.headers.get("retry-after")).toBe("60");
     expect(await db.select().from(handles).where(eq(handles.name, "third-bot"))).toHaveLength(0);
-    // Another address is unaffected.
     expect((await request(app, "POST", "/api/handles", env, { body: { name: "third-bot" }, ip: "198.51.100.9" })).status).toBe(201);
   });
 
@@ -61,16 +59,13 @@ describe("unauthenticated rate limits", () => {
     expect((await request(app, "POST", "/api/handles", env, { body: { name: "alpha-bot", email: shared } })).status).toBe(201);
     expect((await request(app, "POST", "/api/handles", env, { body: { name: "bravo-bot", email: shared } })).status).toBe(201);
     expect(sent).toHaveLength(2);
-    // Third mail to the same mailbox in the window is refused before anything is created.
     const capped = await request(app, "POST", "/api/handles", env, { body: { name: "charlie-bot", email: shared } });
     expect(capped.status).toBe(429);
     expect(sent).toHaveLength(2);
     expect(await db.select().from(handles).where(eq(handles.name, "charlie-bot"))).toHaveLength(0);
-    // Claiming without an email sends nothing and is not counted here.
     const c = await request(app, "POST", "/api/handles", env, { body: { name: "charlie-bot" } });
     expect(c.status).toBe(201);
 
-    // Re-pointing an unverified email sends a mail each time; the caller's address caps it.
     const patch = (email: string) =>
       request(app, "PATCH", "/api/handles/me", env, { token: c.json.token, body: { email }, ip: "198.51.100.9" });
     expect((await patch("one@owners.example")).status).toBe(200);
@@ -80,7 +75,6 @@ describe("unauthenticated rate limits", () => {
     const [me] = await db.select().from(handles).where(eq(handles.name, "charlie-bot"));
     expect(me!.email).toBe("two@owners.example");
 
-    // Recovery keeps its uniform response; a throttled request just sends nothing.
     const d = await request(app, "POST", "/api/handles", env, { body: { name: "delta-bot", email: "d@owners.example" }, ip: "192.0.2.1" });
     expect(d.status).toBe(201);
     const recover = (ip: string) =>

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -24,8 +24,7 @@
     { "pattern": "hi.new", "custom_domain": true, "zone_name": "hi.new" },
     { "pattern": "www.hi.new", "custom_domain": true, "zone_name": "hi.new" }
   ],
-  // In-memory per-colo throttles for paths that carry no credential (see
-  // lib/ratelimit.ts). Keys: caller IP, plus the target mailbox for email.
+  // Throttles for unauthenticated paths; see lib/ratelimit.ts.
   "ratelimits": [
     { "name": "SIGNUP_LIMIT", "namespace_id": "1001", "simple": { "limit": 10, "period": 60 } },
     { "name": "EMAIL_LIMIT", "namespace_id": "1002", "simple": { "limit": 5, "period": 60 } },

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -24,6 +24,13 @@
     { "pattern": "hi.new", "custom_domain": true, "zone_name": "hi.new" },
     { "pattern": "www.hi.new", "custom_domain": true, "zone_name": "hi.new" }
   ],
+  // In-memory per-colo throttles for paths that carry no credential (see
+  // lib/ratelimit.ts). Keys: caller IP, plus the target mailbox for email.
+  "ratelimits": [
+    { "name": "SIGNUP_LIMIT", "namespace_id": "1001", "simple": { "limit": 10, "period": 60 } },
+    { "name": "EMAIL_LIMIT", "namespace_id": "1002", "simple": { "limit": 5, "period": 60 } },
+    { "name": "LOOKUP_LIMIT", "namespace_id": "1003", "simple": { "limit": 60, "period": 60 } }
+  ],
   "vars": {
     "APP_ORIGIN": "https://hi.new"
   },
@@ -39,6 +46,12 @@
       "placement": { "mode": "off" },
       "workers_dev": false,
       "routes": [{ "pattern": "staging.hi.new", "custom_domain": true, "zone_name": "hi.new" }],
+      // Bindings are not inherited by environments.
+      "ratelimits": [
+        { "name": "SIGNUP_LIMIT", "namespace_id": "2001", "simple": { "limit": 10, "period": 60 } },
+        { "name": "EMAIL_LIMIT", "namespace_id": "2002", "simple": { "limit": 5, "period": 60 } },
+        { "name": "LOOKUP_LIMIT", "namespace_id": "2003", "simple": { "limit": 60, "period": 60 } }
+      ],
       "vars": {
         "APP_ORIGIN": "https://staging.hi.new",
         "STAGE": "staging"


### PR DESCRIPTION
## Summary

Follow-up to a security review of the API. The authenticated surface was sound (hashed tokens, per-handle scoping everywhere, grant checks, CSRF guards). The gaps were all on paths that carry no credential.

- **Rate limits** on claims, verification and recovery mail, and profile lookups, using the Cloudflare Workers rate-limit binding. It is an in-memory per-colo counter, no network hop, so nothing gets slower. Without the binding (tests, bun, local) it is a no-op. Limits are declared in `wrangler.jsonc` for production and staging.
- **Owner sign-in fails closed** when `BETTER_AUTH_SECRET` is missing in production, instead of logging and continuing on a placeholder secret. Better Auth is now built lazily, so bot API requests skip constructing it entirely.
- **Frame headers** (`frame-ancestors 'none'`, `X-Frame-Options: DENY`) on HTML responses, so dashboard one-click forms can't be clickjacked.
- **Stale move links** are retired when an owner starts or cancels an email move, so an older link can't confirm a move to a different address.
- `api.md` notes the 429 behaviour and `Retry-After`.

Deliberately unchanged: OG card rendering and caching, and `/api/stats/claims` (the landing ticker depends on it; names are public by design).

## Test plan

- [x] `bun run typecheck` clean across workspaces
- [x] `bun run test`: 121 API + 14 CLI tests pass, including new `security.test.ts` (throttles, uniform recovery response, secret fail-closed, frame headers) and a superseded-move-link test
- [ ] After deploy: confirm `wrangler deploy` accepts the `ratelimits` bindings and a burst of `POST /api/handles` from one IP returns 429 after 10 in a minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)
