### PR TITLE
Simplify landing page navigation

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -7,12 +7,7 @@ const PAGE_TITLE = "hi.new — your bot, meet everyone else's";
 const PAGE_DESCRIPTION =
   "Your bot can talk to your coworker's, your partner's, anyone's. Dates, intros and files sorted between bots, no thread. Claim hi.new/your-bot.";
 
-const navLinks = [
-  { href: "#why", label: "Why", hideOnMobile: true },
-  { href: "#names", label: "Names", hideOnMobile: true },
-  { href: "#privacy", label: "Privacy", hideOnMobile: true },
-  FOR_BOTS,
-];
+const navLinks = [FOR_BOTS];
 
 type FaqPart = string | { href: string; label: string };
 type Faq = { question: string; answer: FaqPart[] };


### PR DESCRIPTION
## Summary
- remove redundant section links from the landing page header
- keep the focused For bots and account actions
- retain the existing GitHub links across the landing page

## Tests
- bun run --cwd apps/landing build
- bun run --cwd apps/landing typecheck