### PR TITLE
Fix free-name limit error message

### DIFF
--- a/apps/api/src/pages/pages.tsx
+++ b/apps/api/src/pages/pages.tsx
@@ -142,8 +142,12 @@ btn.addEventListener("click",async function(){
       var cod=await co.json();
       if(co.ok&&cod.url){location.href=cod.url;return;}
       err.textContent=cod.hint||cod.error||"Checkout isn't available right now.";
+    }else if(res.status===409&&data.error==="name_taken"){
+      err.textContent="Someone just took it.";
+    }else if(data.error==="email_name_limit"){
+      err.textContent="This email already has "+data.limit+" free names.";
     }else{
-      err.textContent=res.status===409?"Someone just took it.":(data.hint||data.error||"Something went wrong.");
+      err.textContent=data.hint||data.error||"Something went wrong.";
     }
     btn.disabled=false;btn.textContent=${JSON.stringify(buttonLabel)};
     return;

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -791,8 +791,10 @@ const faqText = (answer: FaqPart[]) =>
               return;
             }
             setStatus(cod.hint || cod.error || "checkout isn't available right now", "#C94244");
-          } else if (res.status === 409) {
+          } else if (res.status === 409 && data.error === "name_taken") {
             setStatus("hi.new/" + h + " is taken, try another", "#C94244");
+          } else if (data.error === "email_name_limit") {
+            setStatus("This email already has " + data.limit + " free names.", "#C94244");
           } else {
             setStatus(data.hint || data.error || "something went wrong, try again", "#C94244");
           }

--- a/e2e/claim.spec.ts
+++ b/e2e/claim.spec.ts
@@ -1,6 +1,28 @@
 import { expect, test } from "@playwright/test";
 import { captureScreenshot, expectNoHorizontalOverflow, latestMailTo, linkIn, unique } from "./helpers";
 
+test("a free-name limit is not reported as a taken name", async ({ page }) => {
+  const name = unique("available-name");
+  await page.route("**/api/handles", async (route) => {
+    await route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "email_name_limit", limit: 25 }),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByPlaceholder("yourname").fill(name);
+  await page.getByRole("button", { name: "Claim", exact: true }).click();
+  await expect(page.getByText("This email already has 25 free names.")).toBeVisible();
+  await expect(page.getByText(/is taken/)).toHaveCount(0);
+
+  await page.goto(`/${name}`);
+  await page.getByRole("button", { name: "Claim it free" }).click();
+  await expect(page.getByText("This email already has 25 free names.")).toBeVisible();
+  await expect(page.getByText("Someone just took it.")).toHaveCount(0);
+});
+
 test("claim a name on the landing, hand a setup code to a bot, verify the email", async ({ page, request }, testInfo) => {
   const name = unique("e2e-claim");
   const email = `${name}@example.com`;


### PR DESCRIPTION
## Summary
- show the email free-name limit instead of reporting every name as taken
- reserve the taken-name message for `name_taken` responses
- cover both claim surfaces on desktop and mobile

## Tests
- `bun run typecheck`
- `bun run --cwd apps/landing build`
- `bun run e2e -- e2e/claim.spec.ts --grep "free-name limit"`