### PR TITLE
Add support email to site footer

### DIFF
--- a/apps/landing/src/layouts/ProductShell.astro
+++ b/apps/landing/src/layouts/ProductShell.astro
@@ -2,7 +2,7 @@
 import "@hi-new/ui/tokens.css";
 import "../styles/base.css";
 import "../styles/setup.css";
-import { Nav, NAV_CSS } from "@hi-new/ui";
+import { Footer, Nav, NAV_CSS } from "@hi-new/ui";
 
 interface Props {
   title: string;
@@ -28,17 +28,15 @@ const { title, noindex = false } = Astro.props;
 
     <slot />
 
-    <footer>
-      <a class="wordmark sm" href="/"><span>hi</span><span class="dot">.new</span></a>
-      <div class="footer-links">
-        <a href="/connect">Connect</a>
-        <a href="/skill.md">API</a>
-        <a href="/#faq">FAQ</a>
-        <a href="https://rakazo.com">Rakazo</a>
-        <a href="https://botdirectory.ai">Bot Directory</a>
-      </div>
-      <div class="tagline">&copy; 2026 Inbox Zero Inc.</div>
-    </footer>
+    <Footer
+      className="landing-footer"
+      showWordmark
+      links={[
+        { href: "/#faq", label: "FAQ" },
+        { href: "https://rakazo.com", label: "Rakazo" },
+        { href: "https://botdirectory.ai", label: "Bot Directory" },
+      ]}
+    />
 
   </body>
 </html>

--- a/apps/landing/src/pages/connect.astro
+++ b/apps/landing/src/pages/connect.astro
@@ -2,7 +2,7 @@
 import { BellRing, ChevronDown, KeyRound, LockKeyhole, ShieldCheck } from "lucide-astro";
 import "@hi-new/ui/tokens.css";
 import "../styles/base.css";
-import { Nav, NAV_CSS } from "@hi-new/ui";
+import { Footer, Nav, NAV_CSS } from "@hi-new/ui";
 
 const navLinks = [
   { href: "/skill.md", label: "API reference", hideOnMobile: true },
@@ -129,15 +129,11 @@ const navLinks = [
       </section>
     </main>
 
-    <footer>
-      <a class="wordmark sm" href="/"><span>hi</span><span class="dot">.new</span></a>
-      <div class="footer-links">
-        <a href="/connect">Connect</a>
-        <a href="/skill.md">API</a>
-        <a href="https://github.com/elie222/hi-new">GitHub</a>
-      </div>
-      <div class="tagline">&copy; 2026 Inbox Zero Inc.</div>
-    </footer>
+    <Footer
+      className="landing-footer"
+      showWordmark
+      links={[{ href: "https://github.com/elie222/hi-new", label: "GitHub" }]}
+    />
 
     <style is:global>
       body { background: var(--iz-white); }

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import "@hi-new/ui/tokens.css";
 import "../styles/base.css";
-import { Dialog, DIALOG_CSS, FOR_BOTS, Nav, NAV_CSS } from "@hi-new/ui";
+import { Dialog, DIALOG_CSS, Footer, FOR_BOTS, Nav, NAV_CSS } from "@hi-new/ui";
 
 const PAGE_TITLE = "hi.new — your bot, meet everyone else's";
 const PAGE_DESCRIPTION =
@@ -336,18 +336,16 @@ const faqText = (answer: FaqPart[]) =>
       </div>
     </section>
 
-    <footer>
-      <a class="wordmark sm" href="/"><span>hi</span><span class="dot">.new</span></a>
-      <div class="footer-links">
-        <a href="/connect">Connect</a>
-        <a href="/skill.md">API</a>
-        <a href="#privacy">Privacy</a>
-        <a href="https://github.com/elie222/hi-new">GitHub</a>
-        <a href="https://rakazo.com">Rakazo</a>
-        <a href="https://botdirectory.ai">Bot Directory</a>
-      </div>
-      <div class="tagline">&copy; 2026 Inbox Zero Inc.</div>
-    </footer>
+    <Footer
+      className="landing-footer"
+      showWordmark
+      links={[
+        { href: "#privacy", label: "Privacy" },
+        { href: "https://github.com/elie222/hi-new", label: "GitHub" },
+        { href: "https://rakazo.com", label: "Rakazo" },
+        { href: "https://botdirectory.ai", label: "Bot Directory" },
+      ]}
+    />
 
     <style is:global>
       .wordmark { display: inline-flex; align-items: baseline; }

--- a/packages/ui/src/nav.tsx
+++ b/packages/ui/src/nav.tsx
@@ -94,16 +94,29 @@ export function Nav(props: { links?: NavLink[]; signedIn?: boolean }) {
   );
 }
 
-// Compact footer for the server-rendered product pages (profile, owner
-// dashboard, sign-in). The landing keeps its own, fuller footer.
-export function Footer() {
-  const links = [
-    { href: "/connect", label: "Connect" },
-    { href: "/skill.md", label: "API" },
-    { href: "https://github.com/elie222/hi-new", label: "GitHub" },
-  ];
+// Shared footer for both the static landing pages and server-rendered product
+// pages. Every variant starts with the core links below.
+const FOOTER_LINKS: NavLink[] = [
+  { href: "/connect", label: "Connect" },
+  { href: "/skill.md", label: "API" },
+  { href: "mailto:elie@getinboxzero.com", label: "Support" },
+];
+
+const DEFAULT_FOOTER_LINKS: NavLink[] = [
+  { href: "https://github.com/elie222/hi-new", label: "GitHub" },
+];
+
+export function Footer(props: {
+  links?: NavLink[];
+  showWordmark?: boolean;
+  className?: string;
+} = {}) {
+  const links = [...FOOTER_LINKS, ...(props.links ?? DEFAULT_FOOTER_LINKS)];
   return (
-    <footer className="site-footer">
+    <footer className={props.className ?? "site-footer"}>
+      {props.showWordmark ? (
+        <a className="wordmark sm" href="/"><span>hi</span><span className="dot">.new</span></a>
+      ) : null}
       <div className="footer-links">
         {links.map((l) => <a key={l.href} href={l.href}>{l.label}</a>)}
       </div>


### PR DESCRIPTION
## Summary
- add a support mail link across site footers
- reuse the shared footer component on Astro pages
- preserve page-specific footer links

## Verification
- `bun run --cwd apps/landing build`
- `bun run --cwd packages/ui typecheck`
- `git diff --check`