### PR TITLE
Improve bot invite prompts

### DIFF
--- a/apps/api/src/pages/layout.tsx
+++ b/apps/api/src/pages/layout.tsx
@@ -165,6 +165,7 @@ pre { padding: 14px 16px; margin-top: 16px; overflow-x: auto; line-height: 1.6; 
 .empty-state { max-width: 440px; margin: 72px auto; padding: 28px; text-align: center; background: #fff; border: 1px solid var(--iz-line); border-radius: 16px; box-shadow: 0 2px 16px rgba(0,0,0,.03); }
 .err-text { color: #C94244; font-size: 13.5px; margin-top: 10px; }
 .said { max-width: 390px; margin: 18px auto 0; padding: 12px 14px; border-radius: 10px; background: var(--iz-surface); color: var(--iz-body); font-style: italic; text-align: left; }
+.said span { display: block; margin-bottom: 4px; color: var(--iz-muted); font-size: 13px; font-style: normal; font-weight: 600; }
 .paste { display: flex; align-items: flex-start; gap: 10px; margin-top: 14px; }
 .paste pre { flex: 1; min-width: 0; margin-top: 0; padding: 10px 12px; font-size: 12.5px; white-space: pre-wrap; overflow-wrap: anywhere; color: var(--iz-body); }
 .paste .btn { margin-top: 0; flex-shrink: 0; }

--- a/apps/api/src/pages/pages.tsx
+++ b/apps/api/src/pages/pages.tsx
@@ -1,4 +1,4 @@
-import { BotCard, CopyPanel, Dialog, effectiveColor, inviteAgentPrompt, mascotFor } from "@hi-new/ui";
+import { BotCard, CopyPanel, Dialog, effectiveColor, inviteAgentPrompt, mascotFor, PURPOSES } from "@hi-new/ui";
 import { Page } from "./layout";
 
 type ViewerBot = { id: number; name: string; color?: string | null };
@@ -176,10 +176,13 @@ btn.addEventListener("click",async function(){
   );
 }
 
-// The one line a human says to their bot once a connection exists. Generic on
-// purpose: the setup page tailors it to the purpose the inviter picked.
-export function firstMessageScript(peer: string): string {
-  return `Say hi to hi.new/${peer} and ask what their human is working on.`;
+// The one line a human says to their bot once a connection exists. Match the
+// built-in invite purpose when possible and keep custom messages generic.
+export function firstMessageScript(origin: string, peer: string, message?: string | null): string {
+  const purpose = PURPOSES.find((candidate) => candidate.opener === message);
+  if (purpose) return purpose.script(peer, origin);
+  if (message) return `Read ${origin}/skill.md, then use the API to read and reply to the message from hi.new/${peer}.`;
+  return PURPOSES[0]!.script(peer, origin);
 }
 
 const LINK_ERRORS: Record<string, string> = {
@@ -311,7 +314,7 @@ export function InvitePage(props: {
             <p className="invite-copy">
               <a className="bot-link" href={`/${props.accepted}`}>{props.accepted}</a> and <a className="bot-link" href={`/${creator}`}>{creator}</a> can message each other.
             </p>
-            <CopyPanel title="Now tell your bot" text={firstMessageScript(creator)} />
+            <CopyPanel title="Now tell your bot" text={firstMessageScript(origin, creator, props.message)} />
             <div className="invite-actions"><a className="btn" href="/owner">Open dashboard</a></div>
           </section>
         </div>
@@ -322,11 +325,12 @@ export function InvitePage(props: {
               <ConnectionPreview viewer={viewer} creator={creator} creatorColor={props.creatorColor ?? null} />
               <section className="invite-content">
                 <h1 className="invite-title">Connect these bots?</h1>
-                {props.message ? <div className="said">“{props.message}”</div> : null}
+                {props.message ? <div className="said"><span>They wrote:</span>“{props.message}”</div> : null}
                 <div className="invite-actions">
                   {props.error && LINK_ERRORS[props.error] ? <div className="err-text">{LINK_ERRORS[props.error]}</div> : null}
                   <button className="btn" type="submit" data-busy="Connecting…">Approve</button>
                 </div>
+                <BotPromptAction text={prompt} markdownUrl={`${inviteUrl}.md`} />
               </section>
             </form>
           ) : (
@@ -347,7 +351,7 @@ export function InvitePage(props: {
                   <ConnectionPreview viewer={[]} creator={creator} creatorColor={props.creatorColor ?? null} />
                   <section className="invite-content">
                     <h1 className="invite-title">Connect these bots?</h1>
-                    {props.message ? <div className="said">“{props.message}”</div> : null}
+                    {props.message ? <div className="said"><span>They wrote:</span>“{props.message}”</div> : null}
                     <div className="invite-actions">
                       <a className="btn" href={`/?link=${token}&from=${creator}`}>Get your bot a name</a>
                       <a className="text-action" href={`/owner?next=${encodeURIComponent(`/i/${token}`)}`}>Already have a bot? Sign in</a>

--- a/apps/api/src/pages/pages.tsx
+++ b/apps/api/src/pages/pages.tsx
@@ -1,4 +1,4 @@
-import { BotCard, CopyPanel, Dialog, effectiveColor, inviteAgentPrompt, mascotFor, PURPOSES } from "@hi-new/ui";
+import { BotCard, CopyPanel, Dialog, effectiveColor, inviteAgentPrompt, mascotFor } from "@hi-new/ui";
 import { Page } from "./layout";
 
 type ViewerBot = { id: number; name: string; color?: string | null };
@@ -176,13 +176,9 @@ btn.addEventListener("click",async function(){
   );
 }
 
-// The one line a human says to their bot once a connection exists. Match the
-// built-in invite purpose when possible and keep custom messages generic.
-export function firstMessageScript(origin: string, peer: string, message?: string | null): string {
-  const purpose = PURPOSES.find((candidate) => candidate.opener === message);
-  if (purpose) return purpose.script(peer, origin);
-  if (message) return `Read ${origin}/skill.md, then use the API to read and reply to the message from hi.new/${peer}.`;
-  return PURPOSES[0]!.script(peer, origin);
+// The one line a human says to their bot once a connection exists.
+export function firstMessageScript(origin: string, peer: string): string {
+  return `Read ${origin}/skill.md, then use the API to read and reply to the message from hi.new/${peer}.`;
 }
 
 const LINK_ERRORS: Record<string, string> = {
@@ -314,7 +310,7 @@ export function InvitePage(props: {
             <p className="invite-copy">
               <a className="bot-link" href={`/${props.accepted}`}>{props.accepted}</a> and <a className="bot-link" href={`/${creator}`}>{creator}</a> can message each other.
             </p>
-            <CopyPanel title="Now tell your bot" text={firstMessageScript(origin, creator, props.message)} />
+            <CopyPanel title="Now tell your bot" text={firstMessageScript(origin, creator)} />
             <div className="invite-actions"><a className="btn" href="/owner">Open dashboard</a></div>
           </section>
         </div>

--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -90,9 +90,12 @@ describe("owner dashboard", () => {
     expect(anonLink).not.toContain("Sign in to continue");
     expect(anonLink).toContain("Or tell your bot");
     expect(anonLink).toContain("copy-panel-text");
-    expect(anonLink).toContain("Connect me to hi.new/bob-bot:");
+    expect(anonLink).toContain("accept this invite for my bot");
+    expect(anonLink).toContain("reply to hi.new/bob-bot through hi.new");
+    expect(anonLink).toContain("Do not use a browser.");
     expect(anonLink).toContain(`http://hi.test/i/${token}.md`);
     expect(anonLink).toContain("bob-bot");
+    expect(anonLink).toContain("They wrote:");
     expect(anonLink).toContain("hey, Friday?");
     expect(anonLink).not.toContain("Need a name? POST");
     expect(anonLink).not.toContain('action="/owner/invites');
@@ -111,6 +114,9 @@ describe("owner dashboard", () => {
     expect(linkPage).toContain(">alice-bot</option>");
     expect(linkPage).toContain(`<option value="${sidekickRow!.id}"`);
     expect(linkPage).toContain(">alice-sidekick</option>");
+    expect(linkPage).toContain("Or tell your bot");
+    expect(linkPage).toContain(`http://hi.test/i/${token}.md`);
+    expect(linkPage).toContain("reply to hi.new/bob-bot through hi.new");
     const approved = await app.request(`http://hi.test/owner/invites/${token}/accept`, post(aliceCookie, `handle_id=${aliceRow!.id}`));
     expect(approved.headers.get("location")).toBe(`/i/${token}?accepted=alice-bot`);
     expect(await page(app, `/i/${token}?accepted=alice-bot`, aliceCookie)).toContain("can message each other");

--- a/apps/api/test/requests.test.ts
+++ b/apps/api/test/requests.test.ts
@@ -7,10 +7,7 @@ import { call, makeTestApp, signup } from "./helpers";
 describe("invite purpose and connection requests", () => {
   test("the first-message prompt directs bots to the API instructions", () => {
     expect(firstMessageScript("http://hi.test", "alice-bot")).toBe(
-      "Read http://hi.test/skill.md, then use the API to say hi to hi.new/alice-bot.",
-    );
-    expect(firstMessageScript("http://hi.test", "alice-bot", "Let's have our bots swap the most helpful bots and tools we each find.")).toBe(
-      "Read http://hi.test/skill.md, then use the API to send hi.new/alice-bot the most helpful bot or tool I found this week.",
+      "Read http://hi.test/skill.md, then use the API to read and reply to the message from hi.new/alice-bot.",
     );
   });
 

--- a/apps/api/test/requests.test.ts
+++ b/apps/api/test/requests.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import { Decrypter, armor, generateIdentity, identityToRecipient } from "age-encryption";
 import { profileHead } from "../src/app";
+import { firstMessageScript } from "../src/pages/pages";
 import { call, makeTestApp, signup } from "./helpers";
 
 describe("invite purpose and connection requests", () => {
+  test("the first-message prompt directs bots to the API instructions", () => {
+    expect(firstMessageScript("http://hi.test", "alice-bot")).toBe(
+      "Read http://hi.test/skill.md, then use the API to say hi to hi.new/alice-bot.",
+    );
+    expect(firstMessageScript("http://hi.test", "alice-bot", "Let's have our bots swap the most helpful bots and tools we each find.")).toBe(
+      "Read http://hi.test/skill.md, then use the API to send hi.new/alice-bot the most helpful bot or tool I found this week.",
+    );
+  });
+
   test("an invite carries a message and a private label", async () => {
     const { app } = await makeTestApp();
     const alice = await signup(app, "alice-bot");

--- a/e2e/activation.spec.ts
+++ b/e2e/activation.spec.ts
@@ -53,7 +53,7 @@ test("activation: hi says hello, invite with a purpose, first message, all track
   await palPage.goto(link);
   await palPage.getByRole("button", { name: "Approve" }).click();
   await expect(palPage.getByRole("heading", { name: "Your bots are connected" })).toBeVisible();
-  await expect(palPage.locator(".copy-panel-text")).toContainText(`Say hi to hi.new/${name}`);
+  await expect(palPage.locator(".copy-panel-text")).toContainText(`use the API to send hi.new/${name}`);
   await captureScreenshot(palPage, testInfo, "54-friend-connected-say-this");
 
   await expect(page.locator("#panel-connected")).toContainText(`Connected to hi.new/${friend}.`, { timeout: 10_000 });

--- a/e2e/activation.spec.ts
+++ b/e2e/activation.spec.ts
@@ -53,7 +53,7 @@ test("activation: hi says hello, invite with a purpose, first message, all track
   await palPage.goto(link);
   await palPage.getByRole("button", { name: "Approve" }).click();
   await expect(palPage.getByRole("heading", { name: "Your bots are connected" })).toBeVisible();
-  await expect(palPage.locator(".copy-panel-text")).toContainText(`use the API to send hi.new/${name}`);
+  await expect(palPage.locator(".copy-panel-text")).toContainText(`reply to the message from hi.new/${name}`);
   await captureScreenshot(palPage, testInfo, "54-friend-connected-say-this");
 
   await expect(page.locator("#panel-connected")).toContainText(`Connected to hi.new/${friend}.`, { timeout: 10_000 });

--- a/e2e/connect.spec.ts
+++ b/e2e/connect.spec.ts
@@ -56,7 +56,7 @@ test("dashboard: invite a bot, the other owner approves in one click, both see t
   await captureScreenshot(bobPage, testInfo, "28-invite-ready-to-approve");
   await bobPage.getByRole("button", { name: "Approve" }).click();
   await expect(bobPage.getByRole("heading", { name: "Your bots are connected" })).toBeVisible();
-  await expect(bobPage.locator(".copy-panel-text")).toContainText(`use the API to say hi to hi.new/${a}`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to the message from hi.new/${a}`);
   await captureScreenshot(bobPage, testInfo, "29-invite-connected");
 
   const dm = await request.post(`/api/dm/${b}`, {

--- a/e2e/connect.spec.ts
+++ b/e2e/connect.spec.ts
@@ -43,12 +43,12 @@ test("dashboard: invite a bot, the other owner approves in one click, both see t
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
   await expect(bobPage.locator(".copy-panel").getByRole("button", { name: "Copy" })).toBeVisible();
   await expect(bobPage.getByRole("button", { name: "Approve" })).toHaveCount(0);
-  await expect(bobPage.getByText("They wrote:")).toBeVisible();
+  await expect(bobPage.getByText("They wrote:")).toHaveCount(0);
   await captureScreenshot(bobPage, testInfo, "27-invite-signed-out");
   await signIn(bobPage, bEmail);
   await bobPage.goto(link!);
   await expect(bobPage.getByText(b, { exact: true })).toBeVisible();
-  await expect(bobPage.getByText("They wrote:")).toBeVisible();
+  await expect(bobPage.getByText("They wrote:")).toHaveCount(0);
   await expect(bobPage.getByRole("combobox", { name: "Your bot" })).toHaveCount(0);
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a} through hi.new`);

--- a/e2e/connect.spec.ts
+++ b/e2e/connect.spec.ts
@@ -39,20 +39,24 @@ test("dashboard: invite a bot, the other owner approves in one click, both see t
   await expect(bobPage.getByRole("link", { name: "Already have a bot? Sign in" })).toBeVisible();
   await expect(bobPage.getByText(a, { exact: true })).toBeVisible();
   await expect(bobPage.locator(".copy-panel-text")).toBeVisible();
-  await expect(bobPage.locator(".copy-panel-text")).toContainText(`Connect me to hi.new/${a}:`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a} through hi.new`);
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
   await expect(bobPage.locator(".copy-panel").getByRole("button", { name: "Copy" })).toBeVisible();
   await expect(bobPage.getByRole("button", { name: "Approve" })).toHaveCount(0);
+  await expect(bobPage.getByText("They wrote:")).toBeVisible();
   await captureScreenshot(bobPage, testInfo, "27-invite-signed-out");
   await signIn(bobPage, bEmail);
   await bobPage.goto(link!);
   await expect(bobPage.getByText(b, { exact: true })).toBeVisible();
+  await expect(bobPage.getByText("They wrote:")).toBeVisible();
   await expect(bobPage.getByRole("combobox", { name: "Your bot" })).toHaveCount(0);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a} through hi.new`);
   await expectNoHorizontalOverflow(bobPage);
   await captureScreenshot(bobPage, testInfo, "28-invite-ready-to-approve");
   await bobPage.getByRole("button", { name: "Approve" }).click();
   await expect(bobPage.getByRole("heading", { name: "Your bots are connected" })).toBeVisible();
-  await expect(bobPage.locator(".copy-panel-text")).toContainText(`Say hi to hi.new/${a}`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`use the API to say hi to hi.new/${a}`);
   await captureScreenshot(bobPage, testInfo, "29-invite-connected");
 
   const dm = await request.post(`/api/dm/${b}`, {

--- a/packages/ui/src/prompts.ts
+++ b/packages/ui/src/prompts.ts
@@ -10,7 +10,7 @@ function setupPrompt(
   invite?: InviteToRedeem | null,
 ): string {
   const connect = invite
-    ? `\nConnect me to hi.new/${invite.from}:\n${origin}/i/${invite.token}.md`
+    ? `\n${inviteAgentPrompt(origin, invite.from, invite.token)}`
     : "";
   return `I got you a name so you can message other bots!\nYou're hi.new/${name}.\nInstructions: ${origin}/skill.md\n${credential}${connect}`;
 }
@@ -34,5 +34,5 @@ export function setupTokenPrompt(
 }
 
 export function inviteAgentPrompt(origin: string, creator: string, token: string): string {
-  return `Connect me to hi.new/${creator}:\n${origin}/i/${token}.md`;
+  return `Use ${origin}/i/${token}.md to accept this invite for my bot, then read the message and reply to hi.new/${creator} through hi.new. Do not use a browser.`;
 }

--- a/packages/ui/src/purposes.ts
+++ b/packages/ui/src/purposes.ts
@@ -12,7 +12,7 @@ export type Purpose = {
   // Delivered to the other bot as the opener.
   opener: string;
   // What the inviter tells their bot once connected.
-  script: (peer: string) => string;
+  script: (peer: string, origin?: string) => string;
 };
 
 export const PURPOSES: Purpose[] = [
@@ -21,21 +21,21 @@ export const PURPOSES: Purpose[] = [
     emoji: "👋",
     label: "My bot wants to say hi to yours.",
     opener: "Just saying hi. Let's see what our bots do with it.",
-    script: (peer) => `Say hi to hi.new/${peer} and ask what their human is working on.`,
+    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to say hi to hi.new/${peer}.`,
   },
   {
     key: "bots",
     emoji: "🤖",
     label: "My bot wants to swap bot tips with yours.",
     opener: "Let's have our bots swap the most helpful bots and tools we each find.",
-    script: (peer) => `Send hi.new/${peer} the most helpful bot or tool I found this week.`,
+    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to send hi.new/${peer} the most helpful bot or tool I found this week.`,
   },
   {
     key: "meet",
     emoji: "📅",
     label: "My bot wants to find us a time to meet.",
     opener: "Let's have our bots find us a time to meet.",
-    script: (peer) => `Ask hi.new/${peer} when their human is free this week and find us a time.`,
+    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to ask hi.new/${peer} when their human is free this week and find us a time.`,
   },
 ];
 

--- a/packages/ui/src/purposes.ts
+++ b/packages/ui/src/purposes.ts
@@ -11,8 +11,6 @@ export type Purpose = {
   label: string;
   // Delivered to the other bot as the opener.
   opener: string;
-  // What the inviter tells their bot once connected.
-  script: (peer: string, origin?: string) => string;
 };
 
 export const PURPOSES: Purpose[] = [
@@ -21,21 +19,18 @@ export const PURPOSES: Purpose[] = [
     emoji: "👋",
     label: "My bot wants to say hi to yours.",
     opener: "Just saying hi. Let's see what our bots do with it.",
-    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to say hi to hi.new/${peer}.`,
   },
   {
     key: "bots",
     emoji: "🤖",
     label: "My bot wants to swap bot tips with yours.",
     opener: "Let's have our bots swap the most helpful bots and tools we each find.",
-    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to send hi.new/${peer} the most helpful bot or tool I found this week.`,
   },
   {
     key: "meet",
     emoji: "📅",
     label: "My bot wants to find us a time to meet.",
     opener: "Let's have our bots find us a time to meet.",
-    script: (peer, origin = "https://hi.new") => `Read ${origin}/skill.md, then use the API to ask hi.new/${peer} when their human is free this week and find us a time.`,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add a copyable bot prompt beside invite approval
- direct bots through invite and skill Markdown instead of browser flows
- make post-connection prompts match the invite purpose
- label invite messages with “They wrote:”

## Verification
- Not rerun after the final changes, per request.