### PR TITLE
Shorten bot invite prompt

### DIFF
--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -91,7 +91,7 @@ describe("owner dashboard", () => {
     expect(anonLink).toContain("Or tell your bot");
     expect(anonLink).toContain("copy-panel-text");
     expect(anonLink).toContain("accept this invite for my bot");
-    expect(anonLink).toContain("reply to hi.new/bob-bot through hi.new");
+    expect(anonLink).toContain("reply to hi.new/bob-bot.");
     expect(anonLink).toContain("Do not use a browser.");
     expect(anonLink).toContain(`http://hi.test/i/${token}.md`);
     expect(anonLink).toContain("bob-bot");
@@ -116,7 +116,7 @@ describe("owner dashboard", () => {
     expect(linkPage).toContain(">alice-sidekick</option>");
     expect(linkPage).toContain("Or tell your bot");
     expect(linkPage).toContain(`http://hi.test/i/${token}.md`);
-    expect(linkPage).toContain("reply to hi.new/bob-bot through hi.new");
+    expect(linkPage).toContain("reply to hi.new/bob-bot.");
     const approved = await app.request(`http://hi.test/owner/invites/${token}/accept`, post(aliceCookie, `handle_id=${aliceRow!.id}`));
     expect(approved.headers.get("location")).toBe(`/i/${token}?accepted=alice-bot`);
     expect(await page(app, `/i/${token}?accepted=alice-bot`, aliceCookie)).toContain("can message each other");

--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -92,7 +92,6 @@ describe("owner dashboard", () => {
     expect(anonLink).toContain("copy-panel-text");
     expect(anonLink).toContain("accept this invite for my bot");
     expect(anonLink).toContain("reply to hi.new/bob-bot.");
-    expect(anonLink).toContain("Do not use a browser.");
     expect(anonLink).toContain(`http://hi.test/i/${token}.md`);
     expect(anonLink).toContain("bob-bot");
     expect(anonLink).toContain("They wrote:");

--- a/e2e/connect.spec.ts
+++ b/e2e/connect.spec.ts
@@ -39,7 +39,7 @@ test("dashboard: invite a bot, the other owner approves in one click, both see t
   await expect(bobPage.getByRole("link", { name: "Already have a bot? Sign in" })).toBeVisible();
   await expect(bobPage.getByText(a, { exact: true })).toBeVisible();
   await expect(bobPage.locator(".copy-panel-text")).toBeVisible();
-  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a} through hi.new`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a}.`);
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
   await expect(bobPage.locator(".copy-panel").getByRole("button", { name: "Copy" })).toBeVisible();
   await expect(bobPage.getByRole("button", { name: "Approve" })).toHaveCount(0);
@@ -51,7 +51,7 @@ test("dashboard: invite a bot, the other owner approves in one click, both see t
   await expect(bobPage.getByText("They wrote:")).toHaveCount(0);
   await expect(bobPage.getByRole("combobox", { name: "Your bot" })).toHaveCount(0);
   await expect(bobPage.locator(".copy-panel-text")).toContainText(`${link}.md`);
-  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a} through hi.new`);
+  await expect(bobPage.locator(".copy-panel-text")).toContainText(`reply to hi.new/${a}.`);
   await expectNoHorizontalOverflow(bobPage);
   await captureScreenshot(bobPage, testInfo, "28-invite-ready-to-approve");
   await bobPage.getByRole("button", { name: "Approve" }).click();

--- a/packages/ui/src/prompts.ts
+++ b/packages/ui/src/prompts.ts
@@ -34,5 +34,5 @@ export function setupTokenPrompt(
 }
 
 export function inviteAgentPrompt(origin: string, creator: string, token: string): string {
-  return `Use ${origin}/i/${token}.md to accept this invite for my bot, then read the message and reply to hi.new/${creator} through hi.new. Do not use a browser.`;
+  return `Use ${origin}/i/${token}.md to accept this invite for my bot, then read the message and reply to hi.new/${creator}.`;
 }


### PR DESCRIPTION
Removes the redundant hi.new and browser instructions from the bot invite prompt.\n\nTests not run per request.