### PR TITLE
Fix paid claim state after sign-in

### DIFF
--- a/apps/api/src/routes/stripe.ts
+++ b/apps/api/src/routes/stripe.ts
@@ -31,7 +31,9 @@ stripeRoutes.post("/buy/:name/checkout", async (c) => {
       409,
     );
   }
-  if (handle.status === "active") return c.json({ error: "name_taken" }, 409);
+  if (handle.status === "active") {
+    return c.json({ error: "name_taken", hint: `hi.new/${name} is already active.` }, 409);
+  }
 
   const origin = c.get("origin");
   const url = await createSubscriptionCheckout(stripeClient(key), {

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -102,6 +102,16 @@ describe("subscriptions", () => {
     expect(me.status).toBe(200);
     expect(me.json.auto_renew).toBe(true);
     expect(me.json.renewal.warning).toBeUndefined();
+
+    const secondCheckout = await app.request(
+      "http://hi.test/buy/vlad/checkout",
+      { method: "POST", headers: { accept: "application/json" } },
+      stripeEnv,
+    );
+    expect(secondCheckout.status).toBe(409);
+    const secondCheckoutBody = (await secondCheckout.json()) as { error: string; hint: string };
+    expect(secondCheckoutBody.error).toBe("name_taken");
+    expect(secondCheckoutBody.hint).toBe("hi.new/vlad is already active.");
   });
 
   test("webhook rejects a bad signature and replays are idempotent", async () => {

--- a/apps/landing/src/components/SetupFlow.tsx
+++ b/apps/landing/src/components/SetupFlow.tsx
@@ -17,7 +17,7 @@ import {
   XIcon,
   type BotColor,
 } from "@hi-new/ui";
-import { readClaim } from "../lib/claim";
+import { markClaimActive, readClaim } from "../lib/claim";
 import LiveHome from "./LiveHome";
 
 type Session = {
@@ -116,7 +116,7 @@ const desktop = typeof navigator !== "undefined" && !/Android|iPhone|iPad|iPod/i
 
 export default function SetupFlow() {
   const [session, setSession] = useState<Session | null>(null);
-  const [mode, setMode] = useState<"flow" | "unpaid" | "activating" | "botPaid">("flow");
+  const [mode, setMode] = useState<"flow" | "checking" | "unpaid" | "activating" | "botPaid">("flow");
   const [payErr, setPayErr] = useState("");
   const [paying, setPaying] = useState(false);
   const [screen, setScreen] = useState<"boot" | "ceremony" | "paste" | "email" | "live">("boot");
@@ -186,13 +186,6 @@ export default function SetupFlow() {
     };
     setSession(s);
 
-    // Reserved but unpaid (e.g. backed out of checkout): pay, or go free.
-    if (claim?.paid && !paidReturn) {
-      history.replaceState(null, "", "/" + name + "/setup");
-      setMode("unpaid");
-      return;
-    }
-
     const start = () => {
       // The ceremony plays once per name — tracked explicitly, so a reload
       // resumes at the paste step but a fresh claim always gets its moment.
@@ -232,6 +225,27 @@ export default function SetupFlow() {
       })();
     };
 
+    // The saved claim can outlive the payment redirect. OAuth also returns
+    // without ?paid=1, so ask the authenticated endpoint before showing the
+    // reservation as unpaid again.
+    if (claim?.paid && !paidReturn) {
+      setMode("checking");
+      void (async () => {
+        try {
+          const res = await fetch("/api/handles/me", { headers: auth(token!), cache: "no-store" });
+          if (res.ok) {
+            markClaimActive(name);
+            setMode("flow");
+            start();
+            return;
+          }
+        } catch { /* fall through to the saved reservation */ }
+        history.replaceState(null, "", "/" + name + "/setup");
+        setMode("unpaid");
+      })();
+      return;
+    }
+
     if (!paidReturn) return void start();
 
     // Back from Stripe: the webhook may not have landed yet, so poll the
@@ -245,6 +259,7 @@ export default function SetupFlow() {
         if (res.status === 200) {
           const profile = await res.json();
           if (!token) return void setMode("botPaid");
+          markClaimActive(name);
           if (isBotColor(claim?.color) && claim!.color !== profile.color) {
             fetch("/api/handles/me", {
               method: "PATCH",
@@ -305,7 +320,17 @@ export default function SetupFlow() {
       });
       const data = await res.json();
       if (res.ok && data.url) return void (location.href = data.url);
-      setPayErr(data.hint || data.error || "Checkout isn't available right now.");
+      if (data.error === "name_taken") {
+        const me = await fetch("/api/handles/me", { headers: auth(token), cache: "no-store" }).catch(() => null);
+        if (me?.ok) {
+          markClaimActive(name);
+          location.reload();
+          return;
+        }
+        setPayErr(`hi.new/${name} is already active.`);
+      } else {
+        setPayErr(data.hint || "Checkout isn't available right now.");
+      }
     } catch {
       setPayErr("Network error. Try again.");
     }
@@ -357,6 +382,7 @@ export default function SetupFlow() {
       {mode === "unpaid" && (
         <Headline title="Almost yours." sub={<>hi.new/{name} is reserved for 24 hours. Pay to activate it, or pick a longer name for free.</>} />
       )}
+      {mode === "checking" && <Headline title="Checking your name." sub={<>Confirming hi.new/{name}&hellip;</>} />}
       {mode === "activating" && <Headline title="Payment received." sub={<>Activating hi.new/{name}&hellip;</>} />}
       {mode === "botPaid" && (
         <Headline title={<>It&rsquo;s yours.</>} sub="The token your bot got when it claimed the name is now active. Nothing else to do." />

--- a/apps/landing/src/lib/claim.ts
+++ b/apps/landing/src/lib/claim.ts
@@ -17,3 +17,11 @@ export function readClaim(): Claim | null {
   const raw = sessionStorage.getItem("hi_claim");
   return raw ? JSON.parse(raw) : null;
 }
+
+export function markClaimActive(name: string): void {
+  const claim = readClaim();
+  if (!claim || claim.name !== name) return;
+  delete claim.paid;
+  delete claim.checkout_url;
+  sessionStorage.setItem("hi_claim", JSON.stringify(claim));
+}

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, expectNoHorizontalOverflow, unique } from "./helpers";
+import { captureScreenshot, expectNoHorizontalOverflow, unique, uniquePaidName } from "./helpers";
 
 test("setup shell keeps the footer down before React loads", async ({ page }) => {
   await page.route("**/_astro/SetupFlow.*.js", (route) => route.abort());
@@ -106,4 +106,52 @@ test("react setup flow: bare /setup canonicalizes, skip email, Back walks the st
   await expect(page.getByRole("button", { name: /say hi to yours/ })).toBeVisible();
   await page.goBack();
   await expect(page).toHaveURL(/step=email/);
+});
+
+test("paid setup recognizes an activated claim after sign-in returns", async ({ page, request }) => {
+  const name = uniquePaidName();
+  const claim = await request.post("/api/handles", { data: { name } });
+  expect(claim.status()).toBe(402);
+  const body = await claim.json();
+
+  await page.goto("/");
+  await page.evaluate(
+    (saved) => sessionStorage.setItem("hi_claim", JSON.stringify(saved)),
+    { name, token: body.token, paid: true, price_usd_per_year: body.price_usd_per_year, checkout_url: body.checkout_url },
+  );
+  await page.route("**/api/handles/me", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ name, color: "blue", email: null, email_verified: false }),
+    });
+  });
+
+  await page.goto(`/${name}/setup?step=email`);
+  await expect(page.getByText("lose this name")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Almost yours." })).toHaveCount(0);
+  expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem("hi_claim")!).paid)).toBeUndefined();
+  expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem("hi_claim")!).checkout_url)).toBeUndefined();
+});
+
+test("paid setup does not expose raw checkout errors", async ({ page, request }) => {
+  const name = uniquePaidName();
+  const claim = await request.post("/api/handles", { data: { name } });
+  expect(claim.status()).toBe(402);
+  const body = await claim.json();
+
+  await page.goto("/");
+  await page.evaluate(
+    (saved) => sessionStorage.setItem("hi_claim", JSON.stringify(saved)),
+    { name, token: body.token, paid: true, price_usd_per_year: body.price_usd_per_year, checkout_url: body.checkout_url },
+  );
+  await page.route(`**/buy/${name}/checkout`, (route) =>
+    route.fulfill({ status: 409, contentType: "application/json", body: JSON.stringify({ error: "name_taken" }) }),
+  );
+
+  await page.goto(`/${name}/setup`);
+  await page.getByRole("button", { name: /Pay \$/ }).click();
+  await expect(page.getByText(`hi.new/${name} is already active.`)).toBeVisible();
+  await expect(page.getByText("name_taken", { exact: true })).toHaveCount(0);
 });


### PR DESCRIPTION
## What changed
- verify a saved paid claim after sign-in before showing checkout again
- clear stale checkout state once Stripe activation is confirmed
- replace the raw `name_taken` checkout error with user-facing copy

## Verification
- `bun run typecheck`
- `bun test apps/api/test/billing.test.ts apps/api/test/handles.test.ts`
- `bun run e2e -- e2e/setup.spec.ts`