### PR TITLE
Proxy PostHog analytics through Cloudflare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ playwright-report/
 .deepsec/
 
 apps/landing/public/analytics.js
+apps/landing/public/site.js

--- a/apps/api/src/app.tsx
+++ b/apps/api/src/app.tsx
@@ -124,7 +124,7 @@ export function createApp(overrides?: {
 }) {
   const app = new Hono<AppEnv>();
 
-  app.all("/r/*", (c) => proxyAnalytics(c.req.raw));
+  app.all("/__h/*", (c) => proxyAnalytics(c.req.raw));
 
   // www.<host> -> <host>: owner auth only trusts APP_ORIGIN, so forms and
   // cookies must live on the apex.

--- a/apps/api/src/app.tsx
+++ b/apps/api/src/app.tsx
@@ -29,6 +29,7 @@ import { stripeRoutes } from "./routes/stripe";
 import { apiMd, cliPrefix, skillMd } from "./skill";
 import { createMcpRoutes } from "./mcp";
 import { sha256Hex } from "./lib/tokens";
+import { proxyAnalytics } from "./lib/analytics-proxy";
 
 async function findInvite(db: Db, token: string) {
   const [row] = await db
@@ -122,6 +123,8 @@ export function createApp(overrides?: {
   waitUntil?: (promise: Promise<unknown>) => void;
 }) {
   const app = new Hono<AppEnv>();
+
+  app.all("/r/*", (c) => proxyAnalytics(c.req.raw));
 
   // www.<host> -> <host>: owner auth only trusts APP_ORIGIN, so forms and
   // cookies must live on the apex.

--- a/apps/api/src/lib/analytics-proxy.ts
+++ b/apps/api/src/lib/analytics-proxy.ts
@@ -3,7 +3,7 @@ export async function proxyAnalytics(
   send: (request: Request) => Promise<Response> = fetch,
 ): Promise<Response> {
   const incoming = new URL(request.url);
-  const path = incoming.pathname.slice("/r".length);
+  const path = incoming.pathname.slice("/__h".length);
   const asset = path.startsWith("/static/") || path.startsWith("/array/");
   if (!asset && !["/e/", "/batch/", "/i/v0/e/", "/flags/"].includes(path)) {
     return new Response(null, { status: 404 });

--- a/apps/api/src/lib/analytics-proxy.ts
+++ b/apps/api/src/lib/analytics-proxy.ts
@@ -1,0 +1,48 @@
+export async function proxyAnalytics(
+  request: Request,
+  send: (request: Request) => Promise<Response> = fetch,
+): Promise<Response> {
+  const incoming = new URL(request.url);
+  const path = incoming.pathname.slice("/r".length);
+  const asset = path.startsWith("/static/") || path.startsWith("/array/");
+  if (!asset && !["/e/", "/batch/", "/i/v0/e/", "/flags/"].includes(path)) {
+    return new Response(null, { status: 404 });
+  }
+  const methods = asset ? ["GET", "HEAD"] : ["GET", "POST"];
+  if (!methods.includes(request.method)) {
+    return new Response(null, { status: 405, headers: { allow: methods.join(", ") } });
+  }
+
+  const upstream = new URL(asset ? "https://us-assets.i.posthog.com" : "https://us.i.posthog.com");
+  upstream.pathname = path;
+  upstream.search = incoming.search;
+  const headers = new Headers();
+  for (const name of ["content-type", "content-encoding", "accept", "user-agent"]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  const ip = request.headers.get("cf-connecting-ip");
+  if (ip) headers.set("x-forwarded-for", ip);
+
+  try {
+    const response = await send(new Request(upstream, {
+      method: request.method,
+      headers,
+      body: request.method === "POST" ? request.body : null,
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+    }));
+    if (response.status >= 300 && response.status < 400) {
+      return new Response(null, { status: 502 });
+    }
+    const responseHeaders = new Headers();
+    for (const name of ["content-type", "content-encoding", "cache-control", "etag", "retry-after"]) {
+      const value = response.headers.get(name);
+      if (value) responseHeaders.set(name, value);
+    }
+    if (!asset) responseHeaders.set("cache-control", "no-store");
+    return new Response(response.body, { status: response.status, headers: responseHeaders });
+  } catch {
+    return new Response(null, { status: 502 });
+  }
+}

--- a/apps/api/test/analytics-proxy.test.ts
+++ b/apps/api/test/analytics-proxy.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { createApp } from "../src/app";
+import { proxyAnalytics } from "../src/lib/analytics-proxy";
+
+test("forwards event bytes and trusted IP without application credentials", async () => {
+  const payload = new Uint8Array([31, 139, 8, 0, 255]);
+  const response = await proxyAnalytics(new Request("https://hi.new/r/e/?compression=gzip-js", {
+    method: "POST",
+    headers: {
+      "content-type": "application/octet-stream",
+      cookie: "owner_session=secret",
+      authorization: "Bearer secret",
+      "x-hi-new-claim-token": "secret",
+      referer: "https://hi.new/i/private-token",
+      "cf-connecting-ip": "203.0.113.10",
+      "x-forwarded-for": "spoofed",
+    },
+    body: payload,
+  }), async (upstream) => {
+    expect(upstream.url).toBe("https://us.i.posthog.com/e/?compression=gzip-js");
+    expect(upstream.method).toBe("POST");
+    expect(new Uint8Array(await upstream.arrayBuffer())).toEqual(payload);
+    expect(upstream.headers.get("x-forwarded-for")).toBe("203.0.113.10");
+    for (const name of ["cookie", "authorization", "x-hi-new-claim-token", "referer"]) {
+      expect(upstream.headers.has(name)).toBe(false);
+    }
+    expect(upstream.redirect).toBe("manual");
+    return new Response("ok", { headers: { "set-cookie": "unexpected=secret", "cache-control": "public" } });
+  });
+  expect(await response.text()).toBe("ok");
+  expect(response.headers.has("set-cookie")).toBe(false);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+});
+
+test("routes SDK assets and configuration to the asset host", async () => {
+  for (const path of ["/static/array.js", "/array/test-project/config"]) {
+    const response = await proxyAnalytics(new Request("https://hi.new/r" + path), async (upstream) => {
+      expect(upstream.url).toBe("https://us-assets.i.posthog.com" + path);
+      return new Response("asset", { headers: { "cache-control": "public, max-age=300" } });
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300");
+  }
+});
+
+test("rejects unsupported paths and methods before database middleware", async () => {
+  const app = createApp();
+  expect((await app.request("https://hi.new/r/private")).status).toBe(404);
+  expect((await app.request("https://hi.new/r/e/", { method: "DELETE" })).status).toBe(405);
+  expect((await app.request("https://hi.new/r/static/array.js", { method: "POST" })).status).toBe(405);
+});
+
+test("preserves ingestion errors but contains upstream failures and redirects", async () => {
+  const request = new Request("https://hi.new/r/e/");
+  const rejected = await proxyAnalytics(request, async () => new Response("rate limited", { status: 429 }));
+  expect(rejected.status).toBe(429);
+  expect(await rejected.text()).toBe("rate limited");
+  const failed = await proxyAnalytics(request, async () => { throw new Error("unavailable"); });
+  expect(failed.status).toBe(502);
+  const redirected = await proxyAnalytics(request, async () => Response.redirect("https://other.example", 302));
+  expect(redirected.status).toBe(502);
+  expect(redirected.headers.has("location")).toBe(false);
+});

--- a/apps/api/test/analytics-proxy.test.ts
+++ b/apps/api/test/analytics-proxy.test.ts
@@ -4,7 +4,7 @@ import { proxyAnalytics } from "../src/lib/analytics-proxy";
 
 test("forwards event bytes and trusted IP without application credentials", async () => {
   const payload = new Uint8Array([31, 139, 8, 0, 255]);
-  const response = await proxyAnalytics(new Request("https://hi.new/r/e/?compression=gzip-js", {
+  const response = await proxyAnalytics(new Request("https://hi.new/__h/e/?compression=gzip-js", {
     method: "POST",
     headers: {
       "content-type": "application/octet-stream",
@@ -34,7 +34,7 @@ test("forwards event bytes and trusted IP without application credentials", asyn
 
 test("routes SDK assets and configuration to the asset host", async () => {
   for (const path of ["/static/array.js", "/array/test-project/config"]) {
-    const response = await proxyAnalytics(new Request("https://hi.new/r" + path), async (upstream) => {
+    const response = await proxyAnalytics(new Request("https://hi.new/__h" + path), async (upstream) => {
       expect(upstream.url).toBe("https://us-assets.i.posthog.com" + path);
       return new Response("asset", { headers: { "cache-control": "public, max-age=300" } });
     });
@@ -45,13 +45,13 @@ test("routes SDK assets and configuration to the asset host", async () => {
 
 test("rejects unsupported paths and methods before database middleware", async () => {
   const app = createApp();
-  expect((await app.request("https://hi.new/r/private")).status).toBe(404);
-  expect((await app.request("https://hi.new/r/e/", { method: "DELETE" })).status).toBe(405);
-  expect((await app.request("https://hi.new/r/static/array.js", { method: "POST" })).status).toBe(405);
+  expect((await app.request("https://hi.new/__h/private")).status).toBe(404);
+  expect((await app.request("https://hi.new/__h/e/", { method: "DELETE" })).status).toBe(405);
+  expect((await app.request("https://hi.new/__h/static/array.js", { method: "POST" })).status).toBe(405);
 });
 
 test("preserves ingestion errors but contains upstream failures and redirects", async () => {
-  const request = new Request("https://hi.new/r/e/");
+  const request = new Request("https://hi.new/__h/e/");
   const rejected = await proxyAnalytics(request, async () => new Response("rate limited", { status: 429 }));
   expect(rejected.status).toBe(429);
   expect(await rejected.text()).toBe("rate limited");

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -6,7 +6,7 @@ import { defineConfig } from "astro/config";
 // under Astro's HMR server. Astro keeps its own pages (/, /connect, /profile, /setup)
 // and assets; the Worker handles the API, checkout, invites, and skill.md.
 const worker = "http://localhost:8787";
-const workerPaths = ["/api", "/buy", "/i/", "/g/", "/r/", "/skill.md", "/owner", "/recover", "/mcp"];
+const workerPaths = ["/api", "/buy", "/i/", "/g/", "/__h/", "/skill.md", "/owner", "/recover", "/mcp"];
 
 export default defineConfig({
   site: "https://hi.new",

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -6,7 +6,7 @@ import { defineConfig } from "astro/config";
 // under Astro's HMR server. Astro keeps its own pages (/, /connect, /profile, /setup)
 // and assets; the Worker handles the API, checkout, invites, and skill.md.
 const worker = "http://localhost:8787";
-const workerPaths = ["/api", "/buy", "/i/", "/g/", "/skill.md", "/owner", "/recover", "/mcp"];
+const workerPaths = ["/api", "/buy", "/i/", "/g/", "/r/", "/skill.md", "/owner", "/recover", "/mcp"];
 
 export default defineConfig({
   site: "https://hi.new",

--- a/apps/landing/scripts/build-analytics.ts
+++ b/apps/landing/scripts/build-analytics.ts
@@ -1,7 +1,7 @@
 const result = await Bun.build({
   entrypoints: ["../../packages/ui/src/analytics-browser.ts"],
   outdir: "public",
-  naming: "analytics.js",
+  naming: "site.js",
   target: "browser",
   minify: true,
   define: {

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -16,7 +16,7 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
     directRequests.push(route.request().url());
     return route.abort();
   });
-  await page.route("https://hi.new/r/**", async (route) => {
+  await page.route("https://hi.new/__h/**", async (route) => {
     requests.push(route.request().url());
     const body = route.request().postDataBuffer();
     if (body && new URL(route.request().url()).pathname.endsWith("/e/")) {
@@ -29,7 +29,7 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
     await route.fulfill({ json: {} });
   });
   await page.route("https://hi.new/**", async (route) => {
-    if (new URL(route.request().url()).pathname.startsWith("/r/")) return route.fallback();
+    if (new URL(route.request().url()).pathname.startsWith("/__h/")) return route.fallback();
     if (new URL(route.request().url()).pathname === "/site.js") {
       return route.fulfill({ path: resolve("apps/landing/dist/site.js"), contentType: "text/javascript" });
     }
@@ -73,7 +73,7 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
 test("local and staging pages do not contact PostHog", async ({ page }) => {
   const requests: string[] = [];
   page.on("request", (request) => {
-    if (request.url().includes("posthog.com") || new URL(request.url()).pathname.startsWith("/r/")) requests.push(request.url());
+    if (request.url().includes("posthog.com") || new URL(request.url()).pathname.startsWith("/__h/")) requests.push(request.url());
   });
   await page.route("https://*.posthog.com/**", (route) => route.fulfill({ json: {} }));
   await page.goto("/");

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -11,7 +11,12 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
   });
   const events: { event: string; properties: Record<string, unknown> }[] = [];
   const requests: string[] = [];
-  await page.route("https://*.posthog.com/**", async (route) => {
+  const directRequests: string[] = [];
+  await page.route("https://*.posthog.com/**", (route) => {
+    directRequests.push(route.request().url());
+    return route.abort();
+  });
+  await page.route("https://hi.new/r/**", async (route) => {
     requests.push(route.request().url());
     const body = route.request().postDataBuffer();
     if (body && new URL(route.request().url()).pathname.endsWith("/e/")) {
@@ -24,14 +29,15 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
     await route.fulfill({ json: {} });
   });
   await page.route("https://hi.new/**", async (route) => {
-    if (new URL(route.request().url()).pathname === "/analytics.js") {
-      return route.fulfill({ path: resolve("apps/landing/dist/analytics.js"), contentType: "text/javascript" });
+    if (new URL(route.request().url()).pathname.startsWith("/r/")) return route.fallback();
+    if (new URL(route.request().url()).pathname === "/site.js") {
+      return route.fulfill({ path: resolve("apps/landing/dist/site.js"), contentType: "text/javascript" });
     }
     await route.fulfill({ contentType: "text/html", body: `<!doctype html><html><head>
       <title>private-name private-message</title>
       <script>${ANALYTICS_BOOTSTRAP}</script>
       <script>window.hiTrack("claim_started",{source:"landing",paid:false})</script>
-      <script defer src="/analytics.js"></script>
+      <script defer src="/site.js"></script>
       </head><body><button>private-message</button><input value="private@example.com"></body></html>` });
   });
   await page.goto("https://hi.new/i/hni_secret?token=hn_secret#hns_secret", {
@@ -46,7 +52,7 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
   expect(first.properties.$process_person_profile).toBe(false);
 
   await page.getByRole("button").click();
-  await page.addScriptTag({ url: "https://hi.new/analytics.js" });
+  await page.addScriptTag({ url: "https://hi.new/site.js" });
   await page.evaluate(() => window.hiTrack?.("invite_created", { source: "setup" }));
   await expect.poll(() => events.some((event) => event.event === "invite_created")).toBe(true);
   expect(events.filter((event) => event.event === "$pageview")).toHaveLength(1);
@@ -58,6 +64,7 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
   expect(second.properties.$current_url).toBe("https://hi.new/:name/setup");
   expect(second.properties.distinct_id).toBe(first.properties.distinct_id);
   const captured = JSON.stringify({ events, requests });
+  expect(directRequests).toEqual([]);
   for (const secret of ["hn_secret", "hni_secret", "hns_secret", "magic-secret", "private-name", "private-message", "private@example.com"]) {
     expect(captured).not.toContain(secret);
   }
@@ -66,17 +73,17 @@ test("analytics scrubs secrets, queues early events, and retains the browser ide
 test("local and staging pages do not contact PostHog", async ({ page }) => {
   const requests: string[] = [];
   page.on("request", (request) => {
-    if (request.url().includes("posthog.com")) requests.push(request.url());
+    if (request.url().includes("posthog.com") || new URL(request.url()).pathname.startsWith("/r/")) requests.push(request.url());
   });
   await page.route("https://*.posthog.com/**", (route) => route.fulfill({ json: {} }));
   await page.goto("/");
-  expect(await page.locator('script[src="/analytics.js"]').count()).toBe(1);
+  expect(await page.locator('script[src="/site.js"]').count()).toBe(1);
   expect(await page.evaluate(() => window.hiAnalyticsLoaded)).toBeUndefined();
 
   await page.route("https://staging.hi.new/**", (route) => route.fulfill({ contentType: "text/html", body: "<!doctype html><title>Staging</title>" }));
   await page.goto("https://staging.hi.new/");
   await page.addScriptTag({ content: ANALYTICS_BOOTSTRAP });
-  await page.addScriptTag({ path: resolve("apps/landing/dist/analytics.js") });
+  await page.addScriptTag({ path: resolve("apps/landing/dist/site.js") });
   expect(await page.evaluate(() => window.hiAnalyticsLoaded)).toBeUndefined();
   expect(requests).toEqual([]);
 });

--- a/packages/ui/src/analytics-browser.ts
+++ b/packages/ui/src/analytics-browser.ts
@@ -16,7 +16,7 @@ function startAnalytics() {
   if (!__POSTHOG_KEY__ || location.origin !== "https://hi.new" || window.hiAnalyticsLoaded) return;
   window.hiAnalyticsLoaded = true;
   posthog.init(__POSTHOG_KEY__, {
-    api_host: "https://us.i.posthog.com",
+    api_host: "/r",
     ui_host: "https://us.posthog.com",
     defaults: "2026-05-30",
     persistence: "localStorage",

--- a/packages/ui/src/analytics-browser.ts
+++ b/packages/ui/src/analytics-browser.ts
@@ -16,7 +16,7 @@ function startAnalytics() {
   if (!__POSTHOG_KEY__ || location.origin !== "https://hi.new" || window.hiAnalyticsLoaded) return;
   window.hiAnalyticsLoaded = true;
   posthog.init(__POSTHOG_KEY__, {
-    api_host: "/r",
+    api_host: "/__h",
     ui_host: "https://us.posthog.com",
     defaults: "2026-05-30",
     persistence: "localStorage",

--- a/packages/ui/src/analytics-head.tsx
+++ b/packages/ui/src/analytics-head.tsx
@@ -3,6 +3,6 @@ import { ANALYTICS_BOOTSTRAP } from "./analytics";
 export function Analytics() {
   return <>
     <script dangerouslySetInnerHTML={{ __html: ANALYTICS_BOOTSTRAP }} />
-    <script defer src="/analytics.js" />
+    <script defer src="/site.js" />
   </>;
 }


### PR DESCRIPTION
Routes PostHog traffic through the existing Cloudflare Worker at `/__h` and serves the browser bundle as `/site.js`, reducing requests matched by analytics blocklists.

The proxy uses fixed PostHog upstreams, excludes application credentials and private referrers, and handles analytics before database middleware. Existing production-only tracking and payload sanitization remain in place.

Validation: workspace typecheck, four proxy tests, four desktop/mobile analytics tests (including no direct PostHog requests), recovery browser tests, and a successful Wrangler deployment dry run.
