### PR TITLE
Require sign-in before website name claims

### DIFF
--- a/apps/api/src/lib/owner-auth.ts
+++ b/apps/api/src/lib/owner-auth.ts
@@ -107,12 +107,13 @@ export function createOwnerAuth(opts: { db: Db; origin: string; env: OwnerAuthEn
 
 export type OwnerAuth = ReturnType<typeof createOwnerAuth>;
 
-// A post-sign-in destination other than the dashboard: a profile, or the
-// setup page's email step.
+// Only allow known local destinations and claim context through sign-in.
 export function safeNext(value: unknown): string | null {
+  if (value === "/owner") return null;
+  if (typeof value === "string" && /^\/\?claim=[a-z0-9][a-z0-9-]{1,31}(?:&ref=[a-z0-9][a-z0-9-]{1,31})?(?:&link=hni_[\w-]+&from=[a-z0-9][a-z0-9-]{1,31})?$/.test(value)) return value;
   return typeof value === "string" && /^\/(?:[a-z0-9][a-z0-9-]{1,31}(?:\/setup\?step=email)?|i\/hni_[\w-]+)$/.test(value) ? value : null;
 }
 
 export function magicLinkVerifyUrl(token: string, next: string | null = null): string {
-  return `${OWNER_AUTH_PATH}/magic-link/verify?token=${encodeURIComponent(token)}&callbackURL=${encodeURIComponent(next ?? "/owner")}&errorCallbackURL=${encodeURIComponent("/owner?error=link")}`;
+  return `${OWNER_AUTH_PATH}/magic-link/verify?token=${encodeURIComponent(token)}&callbackURL=${encodeURIComponent(next ?? "/owner")}&errorCallbackURL=${encodeURIComponent(`/owner?error=link${next ? `&next=${encodeURIComponent(next)}` : ""}`)}`;
 }

--- a/apps/api/src/pages/owner.tsx
+++ b/apps/api/src/pages/owner.tsx
@@ -217,9 +217,10 @@ const ERRORS: Record<string, string> = {
   oauth: "Sign-in with that provider didn\u2019t complete. Try again, or use email.",
 };
 
-function ProviderButton(props: { provider: "github" | "google"; label: string }) {
+function ProviderButton(props: { provider: "github" | "google"; label: string; next?: string | null }) {
   return (
     <form method="post" action={`/owner/login/${props.provider}`}>
+      {props.next ? <input type="hidden" name="next" value={props.next} /> : null}
       <button className="btn secondary provider" type="submit">Continue with {props.label}</button>
     </form>
   );
@@ -228,6 +229,7 @@ function ProviderButton(props: { provider: "github" | "google"; label: string })
 export function OwnerLoginPage(props: { providers: { github: boolean; google: boolean }; error: string | null; next?: string | null }) {
   const message = props.error ? ERRORS[props.error] ?? "Sign-in didn\u2019t complete. Try again." : null;
   const social = props.providers.github || props.providers.google;
+  const claimName = props.next?.match(/^\/\?claim=([a-z0-9-]+)/)?.[1];
   return (
     <Page title="Sign in — hi.new" description="Sign in to see what your bots are up to.">
       <style
@@ -243,12 +245,12 @@ export function OwnerLoginPage(props: { providers: { github: boolean; google: bo
         }}
       />
       <div className="profile-card">
-        <h1 style={{ fontSize: "30px", marginBottom: "12px" }}>Sign in</h1>
-        <p style={{ marginTop: "0" }}>See what your bots are up to.</p>
+        <h1 style={{ fontSize: "30px", marginBottom: "12px" }}>{claimName ? "Sign in to claim your name" : "Sign in"}</h1>
+        <p style={{ marginTop: "0" }}>{claimName ? `Create an account or sign in to claim hi.new/${claimName}.` : "See what your bots are up to."}</p>
         <div className="signin">
           {message ? <p className="err">{message}</p> : null}
-          {props.providers.github ? <ProviderButton provider="github" label="GitHub" /> : null}
-          {props.providers.google ? <ProviderButton provider="google" label="Google" /> : null}
+          {props.providers.github ? <ProviderButton provider="github" label="GitHub" next={props.next} /> : null}
+          {props.providers.google ? <ProviderButton provider="google" label="Google" next={props.next} /> : null}
           {social ? <div className="or">or</div> : null}
           <form method="post" action="/owner/login">
             {props.next ? <input type="hidden" name="next" value={props.next} /> : null}
@@ -261,26 +263,26 @@ export function OwnerLoginPage(props: { providers: { github: boolean; google: bo
   );
 }
 
-export function OwnerCheckEmailPage(props: { email: string }) {
+export function OwnerCheckEmailPage(props: { email: string; next?: string | null }) {
   return (
     <Page title="Check your email — hi.new">
       <div className="profile-card">
         <h1 style={{ fontSize: "30px", marginBottom: "12px" }}>Check your email</h1>
         <p style={{ marginTop: "0" }}>
           A sign-in link is on its way to {props.email}. It works for 15 minutes. Nothing there?
-          Check spam, or <a href="/owner">request another</a>.
+          Check spam, or <a href={props.next ? `/owner?next=${encodeURIComponent(props.next)}` : "/owner"}>request another</a>.
         </p>
       </div>
     </Page>
   );
 }
 
-export function OwnerConfirmPage(props: { verifyUrl: string | null }) {
+export function OwnerConfirmPage(props: { verifyUrl: string | null; next?: string | null }) {
   return (
     <Page title={props.verifyUrl ? "Sign in — hi.new" : "Link unavailable — hi.new"}>
       <div className="profile-card">
         <h1 style={{ fontSize: "30px", marginBottom: "12px" }}>
-          {props.verifyUrl ? "Open your dashboard?" : "Link unavailable"}
+          {props.verifyUrl ? (props.next ? "Continue to hi.new?" : "Open your dashboard?") : "Link unavailable"}
         </h1>
         <p style={{ marginTop: "0" }}>
           {props.verifyUrl
@@ -289,9 +291,9 @@ export function OwnerConfirmPage(props: { verifyUrl: string | null }) {
         </p>
         <div className="cta-row">
           {props.verifyUrl ? (
-            <a className="btn" href={props.verifyUrl}>Continue to dashboard</a>
+            <a className="btn" href={props.verifyUrl}>{props.next ? "Continue" : "Continue to dashboard"}</a>
           ) : (
-            <a className="btn" href="/owner">Start over</a>
+            <a className="btn" href={props.next ? `/owner?next=${encodeURIComponent(props.next)}` : "/owner"}>Start over</a>
           )}
         </div>
       </div>

--- a/apps/api/src/pages/pages.tsx
+++ b/apps/api/src/pages/pages.tsx
@@ -121,44 +121,13 @@ export function UnclaimedPage(props: { name: string; priceCents: number; origin:
   const price = priceCents > 0 ? `$${(priceCents / 100).toLocaleString()}/yr` : "free";
   const buttonLabel = priceCents > 0 ? `Claim it for ${price}` : "Claim it free";
   const claimScript = `(function(){
-var btn=document.getElementById("claim-here"),err=document.getElementById("claim-err");
-btn.addEventListener("click",async function(){
-  window.hiTrack?.("claim_started",{source:"profile",paid:${priceCents > 0}});
-  btn.disabled=true;btn.textContent="Claiming…";
+document.getElementById("claim-here").addEventListener("click",function(){
+  var next=new URLSearchParams({claim:${JSON.stringify(name)}});
   try{
-    var ref=null;
-    try{
-      var at=Number(localStorage.getItem("hi_ref_at")||0);
-      if(Date.now()-at<30*86400*1000)ref=localStorage.getItem("hi_ref");
-    }catch(e){}
-    var body={name:${JSON.stringify(name)}};
-    if(ref&&ref!==body.name)body.ref=ref;
-    var saved=null;
-    try{saved=JSON.parse(sessionStorage.getItem("hi_claim")||"null")}catch(e){}
-    var claimToken=saved&&saved.name===body.name?saved.token:"hn_"+btoa(String.fromCharCode.apply(null,crypto.getRandomValues(new Uint8Array(32)))).split("+").join("-").split("/").join("_").split("=").join("");
-    try{sessionStorage.setItem("hi_claim",JSON.stringify({name:body.name,token:claimToken}))}catch(e){err.textContent="Enable browser storage before claiming a name.";btn.disabled=false;btn.textContent=${JSON.stringify(buttonLabel)};return;}
-    var res=await fetch("/api/handles",{method:"POST",headers:{"content-type":"application/json","x-hi-new-claim-token":claimToken},body:JSON.stringify(body)});
-    var data=await res.json();
-    if(res.status===201||res.status===402){
-      window.hiTrack?.("claim_created",{source:"profile",paid:res.status===402});
-      try{sessionStorage.setItem("hi_claim",JSON.stringify({name:data.name,token:data.token,paid:res.status===402,price_usd_per_year:data.price_usd_per_year,checkout_url:data.checkout_url}))}catch(e){err.textContent="Claim succeeded. Save this token before leaving: "+data.token;btn.disabled=false;btn.textContent=${JSON.stringify(buttonLabel)};return;}
-      if(res.status===201){location.href="/"+encodeURIComponent(data.name)+"/setup";return;}
-      btn.textContent="Taking you to checkout…";
-      var co=await fetch("/buy/"+encodeURIComponent(data.name)+"/checkout",{method:"POST",headers:{accept:"application/json","x-hi-new-claim-token":data.token}});
-      var cod=await co.json();
-      if(co.ok&&cod.url){window.hiTrack?.("checkout_started",{source:"profile"});location.href=cod.url;return;}
-      err.textContent=cod.hint||cod.error||"Checkout isn't available right now.";
-    }else if(res.status===409&&data.error==="name_taken"){
-      err.textContent="Someone just took it.";
-    }else if(data.error==="email_name_limit"){
-      err.textContent="This email already has "+data.limit+" free names.";
-    }else{
-      err.textContent=data.hint||data.error||"Something went wrong.";
-    }
-    btn.disabled=false;btn.textContent=${JSON.stringify(buttonLabel)};
-    return;
-  }catch(e){err.textContent="Network error. Try again."}
-  btn.disabled=false;btn.textContent=${JSON.stringify(buttonLabel)};
+    var ref=localStorage.getItem("hi_ref"),at=Number(localStorage.getItem("hi_ref_at")||0);
+    if(ref&&Date.now()-at<30*86400*1000)next.set("ref",ref);
+  }catch(e){}
+  location.href="/?"+next;
 });
 })();`;
   return (
@@ -175,7 +144,6 @@ btn.addEventListener("click",async function(){
         <div className="cta-row" style={{ marginTop: "24px" }}>
           <button id="claim-here" className="btn">{buttonLabel}</button>
         </div>
-        <div id="claim-err" className="quiet" style={{ marginTop: "10px" }}></div>
       </div>
       <script dangerouslySetInnerHTML={{ __html: claimScript }} />
     </Page>

--- a/apps/api/src/routes/handles.ts
+++ b/apps/api/src/routes/handles.ts
@@ -110,7 +110,17 @@ function nextSteps(origin: string, hasKey: boolean): string[] {
   ];
 }
 
-handleRoutes.post("/api/handles", async (c) => {
+handleRoutes.on("POST", ["/api/handles", "/api/owner/claims"], async (c) => {
+  const ownerClaim = c.req.path === "/api/owner/claims";
+  if (ownerClaim) {
+    c.header("Cache-Control", "private, no-store");
+    const origin = c.req.header("origin");
+    const site = c.req.header("sec-fetch-site");
+    if ((site && site !== "same-origin" && site !== "none") ||
+        (origin && origin !== c.get("origin") && origin !== new URL(c.req.url).origin)) {
+      return c.json({ error: "forbidden" }, 403);
+    }
+  }
   // mppx needs the untouched Request so the Payment credential and request
   // transport are available after Hono consumes the JSON body.
   const paymentRequest = c.req.raw.clone();
@@ -121,7 +131,14 @@ handleRoutes.post("/api/handles", async (c) => {
   if (!nameCheck.ok) return c.json({ error: nameCheck.error }, 400);
   let email: string | null = null;
   let emailVerifiedAt: Date | null = null;
-  if (body.email != null && body.email !== "") {
+  if (ownerClaim) {
+    const session = await c.get("ownerAuth").api.getSession({ headers: c.req.raw.headers });
+    if (!session?.user.email || !session.user.emailVerified) {
+      return c.json({ error: "sign_in_required", hint: "Sign in to claim your name." }, 401);
+    }
+    email = session.user.email.toLowerCase();
+    emailVerifiedAt = new Date();
+  } else if (body.email != null && body.email !== "") {
     if (!isEmail(body.email)) return c.json({ error: "invalid_email" }, 400);
     email = body.email.toLowerCase();
   } else if (c.get("ownerSignedIn")) {
@@ -156,15 +173,27 @@ handleRoutes.post("/api/handles", async (c) => {
   const origin = c.get("origin");
   const paid = priceCents > 0;
   const paymentCredential = hasMppCredential(paymentRequest);
+  const claimToken = c.req.header("x-hi-new-claim-token")?.trim();
+
+  const [existing] = await db.select().from(handles).where(eq(handles.name, name)).limit(1);
+  const alreadyOwned = ownerClaim && existing?.email === email;
+  const existingTokenMatches = existing && claimToken
+    ? await sha256Hex(claimToken) === existing.bearerHash
+    : false;
+  if (alreadyOwned && !existingTokenMatches) {
+    return c.json({ name, owner_url: existing.status === "active" ? "/owner" : `/buy/${name}` });
+  }
 
   // Sybil brake: a single email can hold a limited number of free names.
-  if (email && priceCents === 0 && !(await emailHasRoom(db, email))) {
+  if (email && priceCents === 0 && !alreadyOwned && !(await emailHasRoom(db, email))) {
     return c.json(
       {
         error: "email_name_limit",
         limit: MAX_FREE_HANDLES_PER_EMAIL,
-        claim_without_email: true,
-        hint: `This email already holds ${MAX_FREE_HANDLES_PER_EMAIL} free names. Use another email, or omit email to claim now and attach one within 7 days. Paid names are unlimited.`,
+        claim_without_email: !ownerClaim,
+        hint: ownerClaim
+          ? `This account already holds ${MAX_FREE_HANDLES_PER_EMAIL} free names. Paid names are unlimited.`
+          : `This email already holds ${MAX_FREE_HANDLES_PER_EMAIL} free names. Use another email, or omit email to claim now and attach one within 7 days. Paid names are unlimited.`,
       },
       409,
     );
@@ -192,7 +221,6 @@ handleRoutes.post("/api/handles", async (c) => {
     }),
   );
 
-  const [existing] = await db.select().from(handles).where(eq(handles.name, name)).limit(1);
   let token: string | undefined;
   let bearerHash: string;
   let handleId: number;
@@ -210,8 +238,7 @@ handleRoutes.post("/api/handles", async (c) => {
 
     bearerHash = existing.bearerHash;
     handleId = existing.id;
-    const claimToken = c.req.header("x-hi-new-claim-token")?.trim();
-    if (!claimToken || (await sha256Hex(claimToken)) !== bearerHash) {
+    if (!existingTokenMatches) {
       return c.json({ error: "name_taken" }, 409);
     }
     token = claimToken;
@@ -231,7 +258,7 @@ handleRoutes.post("/api/handles", async (c) => {
     if (paymentCredential) {
       return c.json({ error: "payment_claim_expired", hint: "Start the Link MPP payment again." }, 409);
     }
-    const suppliedToken = c.req.header("x-hi-new-claim-token")?.trim();
+    const suppliedToken = claimToken;
     if (suppliedToken && !/^hn_[A-Za-z0-9_-]{43}$/.test(suppliedToken)) {
       return c.json({ error: "invalid_claim_token" }, 400);
     }

--- a/apps/api/src/routes/owner.tsx
+++ b/apps/api/src/routes/owner.tsx
@@ -416,7 +416,7 @@ ownerRoutes.post("/owner/login", async (c) => {
     // indistinguishable from the outside. Logged for the operator.
     console.warn("owner sign-in: magic link not sent", (err as Error)?.message ?? err);
   }
-  return renderPage(c, <OwnerCheckEmailPage email={typed} />);
+  return renderPage(c, <OwnerCheckEmailPage email={typed} next={next} />);
 });
 
 ownerRoutes.post("/owner/login/:provider", async (c) => {
@@ -428,12 +428,12 @@ ownerRoutes.post("/owner/login/:provider", async (c) => {
   const form = await c.req.parseBody().catch(() => ({}) as Record<string, unknown>);
   const next = safeNext(form.next);
   const { headers, response } = await c.get("ownerAuth").api.signInSocial({
-    body: { provider, callbackURL: next ?? "/owner", errorCallbackURL: "/owner?error=oauth" },
+    body: { provider, callbackURL: next ?? "/owner", errorCallbackURL: `/owner?error=oauth${next ? `&next=${encodeURIComponent(next)}` : ""}` },
     headers: c.req.raw.headers,
     returnHeaders: true,
   });
   forwardCookies(c, headers);
-  if (!response.url) return c.redirect("/owner?error=oauth", 303);
+  if (!response.url) return c.redirect(`/owner?error=oauth${next ? `&next=${encodeURIComponent(next)}` : ""}`, 303);
   return c.redirect(response.url, 303);
 });
 
@@ -442,13 +442,14 @@ ownerRoutes.post("/owner/login/:provider", async (c) => {
 ownerRoutes.get("/owner/l/:token", async (c) => {
   privatePage(c);
   const token = c.req.param("token");
+  const next = safeNext(c.req.query("next"));
   const [pending] = await c
     .get("db")
     .select({ id: verification.id })
     .from(verification)
     .where(and(or(eq(verification.identifier, await sha256Hex(token)), /^[a-zA-Z]{32}$/.test(token) ? eq(verification.identifier, token) : undefined), gt(verification.expiresAt, new Date())))
     .limit(1);
-  return renderPage(c, <OwnerConfirmPage verifyUrl={pending ? magicLinkVerifyUrl(token, safeNext(c.req.query("next"))) : null} />, pending ? 200 : 410);
+  return renderPage(c, <OwnerConfirmPage next={next} verifyUrl={pending ? magicLinkVerifyUrl(token, next) : null} />, pending ? 200 : 410);
 });
 
 ownerRoutes.post("/owner/logout", async (c) => {

--- a/apps/api/test/owner.test.ts
+++ b/apps/api/test/owner.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { groupInvites, handles, invites, messagePayloads, messages, messageTranscripts } from "../src/db/schema";
+import { safeNext } from "../src/lib/owner-auth";
+import { OwnerLoginPage } from "../src/pages/owner";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { user } from "../src/db/auth-schema";
 import { sha256Hex } from "../src/lib/tokens";
 import { call, connect, makeTestApp, signup, type TestApp } from "./helpers";
 
@@ -521,5 +526,68 @@ describe("owner email moves", () => {
     [handle] = await db.select().from(handles).where(eq(handles.id, row!.id));
     expect(handle!.email).toBe("dave@owners.example");
     expect(handle!.pendingEmail).toBeNull();
+  });
+});
+
+
+describe("website claims", () => {
+  test("anonymous and stale sessions cannot reserve free or paid names, even with an email", async () => {
+    const { app, db } = await makeTestApp();
+    for (const name of ["web-free", "web"]) {
+      for (const cookie of ["", "hi.session_token=invalid"]) {
+        const response = await call(app, "POST", "/api/owner/claims", {
+          body: { name, email: "someone@example.com" }, headers: { cookie },
+        });
+        expect(response.status).toBe(401);
+        expect(response.json.error).toBe("sign_in_required");
+      }
+    }
+    expect(await db.select().from(handles)).toHaveLength(0);
+  });
+
+  test("claims attach only to the verified account and resume without leaking credentials", async () => {
+    const { app, db, sent } = await makeTestApp();
+    const cookie = await signIn(app, sent, "owner@example.com");
+    for (const [name, status] of [["web-free", 201], ["web", 402]] as const) {
+      const token = "hn_" + (status === 201 ? "a" : "b").repeat(43);
+      const options = { body: { name, email: "elsewhere@example.com" }, headers: { cookie, "x-hi-new-claim-token": token } };
+      const claimed = await call(app, "POST", "/api/owner/claims", options);
+      expect(claimed.status).toBe(status);
+      expect(claimed.json).toMatchObject({ email: "owner@example.com", email_verified: true, token });
+      const retry = await call(app, "POST", "/api/owner/claims", options);
+      expect(retry.status).toBe(status);
+      expect(retry.json.token).toBe(token);
+      const resumed = await call(app, "POST", "/api/owner/claims", { body: { name }, headers: { cookie } });
+      expect(resumed.status).toBe(200);
+      expect(resumed.json.owner_url).toBe(status === 201 ? "/owner" : "/buy/web");
+      expect(resumed.json.token).toBeUndefined();
+    }
+    const otherCookie = await signIn(app, sent, "other@example.com");
+    const taken = await call(app, "POST", "/api/owner/claims", { body: { name: "web-free" }, headers: { cookie: otherCookie } });
+    expect(taken.status).toBe(409);
+    expect(taken.json.token).toBeUndefined();
+    await db.update(user).set({ emailVerified: false }).where(eq(user.email, "owner@example.com"));
+    const unverified = await call(app, "POST", "/api/owner/claims", { body: { name: "unverified-web" }, headers: { cookie } });
+    expect(unverified.status).toBe(401);
+  });
+
+  test("cross-site website claims are rejected", async () => {
+    const { app, sent } = await makeTestApp();
+    const cookie = await signIn(app, sent, "owner@example.com");
+    const result = await call(app, "POST", "/api/owner/claims", {
+      body: { name: "cross-site" }, headers: { cookie, origin: "https://elsewhere.example", "sec-fetch-site": "cross-site" },
+    });
+    expect(result.status).toBe(403);
+  });
+
+  test("claim destinations and invite context survive all sign-in forms", () => {
+    const next = "/?claim=new-bot&ref=alice-bot&link=hni_example&from=alice-bot";
+    expect(safeNext(next)).toBe(next);
+    for (const invalid of ["//evil.example", "/?claim=bot&next=https://evil.example", "/?claim=bot#ignored", "/?claim=bot&claim=other", "/?claim=%2F%2Fevil.example"]) {
+      expect(safeNext(invalid)).toBeNull();
+    }
+    const html = renderToStaticMarkup(createElement(OwnerLoginPage, { providers: { github: true, google: true }, error: null, next }));
+    expect(html.match(/name="next"/g)).toHaveLength(3);
+    expect(html).toContain("Sign in to claim your name");
   });
 });

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -41,9 +41,9 @@ const faqs: Faq[] = [
   {
     question: "What happens if the token is lost?",
     answer: [
-      "Recover it. Add an owner email after claiming (your bot can attach it any time) and click the verification link; from then on ",
+      "Website claims are attached to your account. Use ",
       { href: "/recover", label: "hi.new/recover" },
-      " can issue a fresh token and kill the old one. Names with no verified email are released after 7 days.",
+      " to replace a lost token. Agent claims need a verified owner email within 7 days.",
     ],
   },
   {
@@ -709,26 +709,30 @@ const faqText = (answer: FaqPart[]) =>
       });
 
       // Remember referral attribution for 30 days.
-      const refParam = new URLSearchParams(location.search).get("ref");
-      if (refParam && /^[a-z0-9-]{2,32}$/.test(refParam.toLowerCase())) {
-        localStorage.setItem("hi_ref", refParam.toLowerCase());
-        localStorage.setItem("hi_ref_at", String(Date.now()));
+      const searchParams = new URLSearchParams(location.search);
+      const rawRef = searchParams.get("ref")?.toLowerCase();
+      const refParam = rawRef && /^[a-z0-9][a-z0-9-]{1,31}$/.test(rawRef) ? rawRef : null;
+      if (refParam) {
+        try {
+          localStorage.setItem("hi_ref", refParam.toLowerCase());
+          localStorage.setItem("hi_ref_at", String(Date.now()));
+        } catch {}
       }
-      const linkParam = new URLSearchParams(location.search).get("link");
-      const fromParam = new URLSearchParams(location.search).get("from");
+      const linkParam = searchParams.get("link");
+      const fromParam = searchParams.get("from");
       const inviteLink = linkParam && /^hni_[\w-]+$/.test(linkParam) ? linkParam : null;
       const inviteFrom = fromParam && /^[a-z0-9][a-z0-9-]{1,31}$/.test(fromParam.toLowerCase()) ? fromParam.toLowerCase() : null;
       function getRef(): string | null {
-        const at = Number(localStorage.getItem("hi_ref_at") || 0);
-        if (Date.now() - at > 30 * 86400 * 1000) return null;
-        return localStorage.getItem("hi_ref");
+        try {
+          const at = Number(localStorage.getItem("hi_ref_at") || 0);
+          if (Date.now() - at > 30 * 86400 * 1000) return null;
+          return localStorage.getItem("hi_ref");
+        } catch { return null; }
       }
 
       // Price the name immediately with the same rules as the API. Availability
       // remains server-authoritative and is checked when the user submits.
-      let currentPrice: number | null = null;
       function setPrice(price: number | null, name: string) {
-        currentPrice = price;
         claimBtn.textContent = price ? "Claim ($" + price + "/yr)" : "Claim";
         statusEl.style.color = "";
         if (!price) statusEl.textContent = "";
@@ -756,21 +760,35 @@ const faqText = (answer: FaqPart[]) =>
       claimBtn.addEventListener("click", async () => {
         const h = input.value.trim().toLowerCase();
         if (!h) { input.focus(); return; }
-        track("claim_started", { source: "landing", paid: Boolean(currentPrice) });
+        const nameCheck = checkName(h);
+        if (!nameCheck.ok) { setStatus(nameCheck.error, "#C94244"); return; }
+        const paid = nameCheck.priceCents > 0;
+        track("claim_started", { source: "landing", paid });
         const idleLabel = claimBtn.textContent;
         claimBtn.disabled = true;
-        claimBtn.textContent = currentPrice ? "Reserving…" : "Claiming…";
+        claimBtn.textContent = paid ? "Reserving…" : "Claiming…";
         try {
+          const ref = refParam || getRef();
+          const resume = new URLSearchParams({ claim: h });
+          if (ref && ref !== h) resume.set("ref", ref);
+          if (inviteLink && inviteFrom) {
+            resume.set("link", inviteLink);
+            resume.set("from", inviteFrom);
+          }
+          const signInUrl = "/owner?next=" + encodeURIComponent("/?" + resume);
+          const who = await fetch("/api/owner/session", { cache: "no-store" }).then((r) => r.json());
+          if (!who.email) { location.href = signInUrl; return; }
           let pending;
           try { pending = prepareClaim(h); }
           catch { setStatus("Enable browser storage before claiming a name.", "#C94244"); return; }
-          const ref = getRef();
-          const res = await fetch("/api/handles", {
+          const res = await fetch("/api/owner/claims", {
             method: "POST",
             headers: { "content-type": "application/json", "x-hi-new-claim-token": pending.token },
             body: JSON.stringify({ name: h, ...(ref && ref !== h ? { ref } : {}) }),
           });
           const data = await res.json();
+          if (res.status === 401) { location.href = signInUrl; return; }
+          if (res.ok && data.owner_url) { location.href = data.owner_url; return; }
           if (res.status === 201 || res.status === 402) {
             track("claim_created", { source: "landing", paid: res.status === 402 });
             try { sessionStorage.setItem(
@@ -803,7 +821,7 @@ const faqText = (answer: FaqPart[]) =>
               return;
             }
             setStatus(cod.hint || cod.error || "checkout isn't available right now", "#C94244");
-          } else if (res.status === 409 && data.error === "name_taken") {
+          } else if (res.status === 409 && (data.error === "name_taken" || data.error === "name_reserved")) {
             setStatus("hi.new/" + h + " is taken, try another", "#C94244");
           } else if (data.error === "email_name_limit") {
             setStatus("This email already has " + data.limit + " free names.", "#C94244");
@@ -817,6 +835,13 @@ const faqText = (answer: FaqPart[]) =>
           claimBtn.textContent = idleLabel;
         }
       });
+
+      const resumedName = searchParams.get("claim");
+      if (resumedName && checkName(resumedName).ok) {
+        input.value = resumedName;
+        input.dispatchEvent(new Event("input"));
+        claimBtn.click();
+      }
 
       const ticker = document.getElementById("ticker")!;
       const tickerList = document.getElementById("ticker-list")!;

--- a/e2e/activation.spec.ts
+++ b/e2e/activation.spec.ts
@@ -6,6 +6,7 @@ test("activation: hi says hello, invite with a purpose, first message, all track
   const friend = unique("e2e-pal");
   const friendEmail = `${friend}@example.com`;
 
+  await signIn(page, `${name}@example.com`);
   await page.goto("/");
   await page.getByPlaceholder("yourname").fill(name);
   await page.getByRole("button", { name: "Claim", exact: true }).click();
@@ -13,7 +14,6 @@ test("activation: hi says hello, invite with a purpose, first message, all track
   await page.getByRole("button", { name: "Set up your bot" }).click();
   const code = (await page.locator("#bot-prompt").textContent())!.match(/hns_[\w-]+/)![0];
   await page.getByRole("button", { name: "Next" }).click();
-  await page.getByRole("button", { name: "Skip for now" }).click();
   await expect(page.getByRole("heading", { name: "Your bot is live." })).toBeVisible();
 
   await expect(page.locator("#panel-invite")).toContainText("Send a friend an invite:");

--- a/e2e/claim.spec.ts
+++ b/e2e/claim.spec.ts
@@ -1,48 +1,49 @@
 import { expect, test } from "@playwright/test";
-import { captureScreenshot, expectNoHorizontalOverflow, latestMailTo, linkIn, unique } from "./helpers";
+import { captureScreenshot, expectNoHorizontalOverflow, latestMailTo, linkIn, unique, uniquePaidName } from "./helpers";
 
-test("claim a name on the landing, hand a setup code to a bot, verify the email", async ({ page, request }, testInfo) => {
+test("sign in from a different browser before claiming and setting up a name", async ({ page: xBrowser, browser, request }, testInfo) => {
   const name = unique("e2e-claim");
   const email = `${name}@example.com`;
+  await xBrowser.goto("/");
+  await xBrowser.getByPlaceholder("yourname").fill(name);
+  await xBrowser.getByRole("button", { name: "Claim", exact: true }).click();
+  await expect(xBrowser.getByRole("heading", { name: "Sign in to claim your name" })).toBeVisible();
+  expect((await request.get(`/api/handles/${name}`)).status()).toBe(404);
+  expect(await xBrowser.evaluate(() => sessionStorage.getItem("hi_claim"))).toBeNull();
+  await xBrowser.getByPlaceholder("you@example.com").fill(email);
+  await xBrowser.getByRole("button", { name: "Email me a sign-in link" }).click();
+  const mail = await latestMailTo(request, email, "Sign in");
+  expect((await request.get(`/api/handles/${name}`)).status()).toBe(404);
 
-  await page.goto("/");
-  await page.getByPlaceholder("yourname").fill(name);
-  await captureScreenshot(page, testInfo, "10-claim-name-entered");
-  await page.getByRole("button", { name: "Claim", exact: true }).click();
-  await expect(page).toHaveURL(new RegExp(`/${name}/setup`));
-  await expect(page.getByText(`hi.new/${name}`).first()).toBeVisible();
-  await expectNoHorizontalOverflow(page);
-  await captureScreenshot(page, testInfo, "11-setup-its-yours");
-  await page.getByRole("button", { name: "Set up your bot" }).click();
+  const mainBrowser = await browser.newContext();
+  try {
+    const page = await mainBrowser.newPage();
+    await page.goto(linkIn(mail.text, "/owner/l/"));
+    await page.getByRole("link", { name: "Continue", exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`/${name}/setup`));
+    await expect(page.getByText(`hi.new/${name}`).first()).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+    await captureScreenshot(page, testInfo, "11-setup-its-yours");
+    await page.getByRole("button", { name: "Set up your bot" }).click();
+    const prompt = page.locator("#bot-prompt");
+    await expect(prompt).toContainText("Setup code: hns_");
+    const code = (await prompt.textContent())!.match(/hns_[\w-]+/)![0];
+    const swap = await request.post("/api/setup", { data: { code } });
+    expect(swap.status()).toBe(200);
+    const { token } = await swap.json();
+    expect((await request.post("/api/setup", { data: { code } })).status()).toBe(410);
+    const me = await request.get("/api/handles/me", { headers: { authorization: `Bearer ${token}` } });
+    expect(await me.json()).toMatchObject({ email, email_verified: true });
+    await page.getByRole("button", { name: "Next" }).click();
+    await expect(page.locator("#panel-email")).toHaveCount(0);
 
-  const prompt = page.locator("#bot-prompt");
-  await expect(prompt).toContainText("Setup code: hns_");
-  await expect(prompt).not.toContainText("hn_6");
-  const code = (await prompt.textContent())!.match(/hns_[\w-]+/)![0];
-
-  const swap = await request.post("/api/setup", { data: { code } });
-  expect(swap.status()).toBe(200);
-  const { token } = await swap.json();
-  expect(token).toMatch(/^hn_/);
-  expect((await request.post("/api/setup", { data: { code } })).status()).toBe(410);
-
-  await page.getByRole("button", { name: "Next" }).click();
-  await page.getByPlaceholder("you@example.com").fill(email);
-  await page.getByRole("button", { name: "Send link" }).click();
-  await expect(page).toHaveURL(/step=live/);
-  await expect(page.locator("#panel-email")).toHaveCount(0);
-  await captureScreenshot(page, testInfo, "12-setup-email-sent");
-  const verify = await latestMailTo(request, email, `Verify hi.new/${name}`);
-  const verified = await page.goto(linkIn(verify.text, "/v/"));
-  expect(verified?.status()).toBe(200);
-  await expect(page.getByRole("heading", { name: `hi.new/${name} is verified` })).toBeVisible();
-  await captureScreenshot(page, testInfo, "13-email-verified");
-  const me = await request.get("/api/handles/me", { headers: { authorization: `Bearer ${token}` } });
-  expect((await me.json()).email_verified).toBe(true);
-
-  await page.goto(`/${name}/setup?step=live`);
-  await expect(page.locator("#panel-email")).toHaveCount(0);
-  await captureScreenshot(page, testInfo, "14-setup-verified");
+    await page.evaluate(() => sessionStorage.clear());
+    await page.goto(`/?claim=${name}`);
+    await expect(page).toHaveURL(/\/owner$/);
+    await expect(page.getByRole("link", { name: `hi.new/${name}`, exact: true })).toBeVisible();
+  } finally {
+    await mainBrowser.close();
+  }
 });
 
 test("claiming while signed in attaches the owner email", async ({ page, request }, testInfo) => {
@@ -77,4 +78,23 @@ test("claiming while signed in attaches the owner email", async ({ page, request
   await expect(page.getByText(/Ask its owner for an invite link/)).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Set up your bot" })).toBeVisible();
   await captureScreenshot(page, testInfo, "19-owned-bot-profile");
+});
+
+
+test("a paid profile claim signs in before reserving and starting checkout", async ({ page, request }) => {
+  const name = uniquePaidName();
+  const email = `${unique("paid-owner")}@example.com`;
+  await page.route(`**/buy/${name}/checkout`, (route) => route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ hint: "Checkout test" }) }));
+  await page.goto(`/${name}`);
+  await page.getByRole("button", { name: /Claim it for/ }).click();
+  await expect(page.getByRole("heading", { name: "Sign in to claim your name" })).toBeVisible();
+  expect((await request.get(`/api/handles/${name}`)).status()).toBe(404);
+  await page.getByPlaceholder("you@example.com").fill(email);
+  await page.getByRole("button", { name: "Email me a sign-in link" }).click();
+  const mail = await latestMailTo(request, email, "Sign in");
+  await page.goto(linkIn(mail.text, "/owner/l/"));
+  const claimed = page.waitForResponse((res) => res.url().endsWith("/api/owner/claims") && res.status() === 402);
+  await page.getByRole("link", { name: "Continue", exact: true }).click();
+  expect(await (await claimed).json()).toMatchObject({ name, email, email_verified: true });
+  await expect(page.getByText("Checkout test", { exact: true })).toBeVisible();
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -32,9 +32,9 @@ export async function latestMailTo(request: APIRequestContext, to: string, subje
 }
 
 export function linkIn(text: string, pathPrefix: string): string {
-  const m = text.match(new RegExp(`https?://[^\\s]+(${pathPrefix.replace(/\//g, "\\/")}[\\w-]+)`));
-  if (!m) throw new Error(`no ${pathPrefix} link in mail: ${text}`);
-  return m[1]!;
+  const url = text.match(/https?:\/\/[^\s]+/g)?.map((value) => new URL(value)).find((value) => value.pathname.startsWith(pathPrefix));
+  if (!url) throw new Error(`no ${pathPrefix} URL in mail`);
+  return url.pathname + url.search;
 }
 
 // A bot claimed straight through the API (what a bot does on its own).

--- a/e2e/setup-security.spec.ts
+++ b/e2e/setup-security.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
-import { unique } from "./helpers";
+import { signIn, unique } from "./helpers";
 
 test("blocked storage prevents a remote claim", async ({ page }) => {
+  await signIn(page, `${unique("storage-owner")}@example.com`);
   await page.addInitScript(() => {
     Storage.prototype.setItem = () => { throw new DOMException("Blocked", "SecurityError"); };
   });
   let claims = 0;
-  await page.route("**/api/handles", (route) => { claims++; return route.abort(); });
+  await page.route("**/api/owner/claims", (route) => { claims++; return route.abort(); });
   await page.goto("/");
   await page.getByPlaceholder("yourname").fill(unique("storage"));
   await page.getByRole("button", { name: "Claim", exact: true }).click();
@@ -16,6 +17,7 @@ test("blocked storage prevents a remote claim", async ({ page }) => {
 
 test("claim persistence failure preserves the token and displays recovery", async ({ page }) => {
   const name = unique("storage-recovery");
+  await signIn(page, `${unique("storage-owner")}@example.com`);
   await page.addInitScript(() => {
     const original = Storage.prototype.setItem;
     let writes = 0;


### PR DESCRIPTION
Website claims now require a verified owner session before free or paid names are reserved.

The sign-in flow preserves claim, referral, invite, OAuth, and magic-link destinations, then resumes setup or checkout safely. Owner claim retries return the existing owner destination without exposing bearer credentials, while agent API claims keep their existing behavior. Tests cover anonymous rejection, verified ownership, cross-site protection, destination preservation, paid claims, storage failures, and the updated setup flow.

Checks: `bun run typecheck`, `bun run test`, and targeted desktop/mobile Playwright coverage.